### PR TITLE
Divided sub-commands into different packages.

### DIFF
--- a/cmd/auth/activateApiKey.go
+++ b/cmd/auth/activateApiKey.go
@@ -12,18 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package auth
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/infostellarinc/stellarcli/pkg/auth"
 )
 
-// satelliteCmd represents the satellite command
-var satelliteCmd = &cobra.Command{
-	Use:   "satellite",
-	Short: "Commands for working with satellites",
-}
-
-func init() {
-	rootCmd.AddCommand(satelliteCmd)
+// activateApiKeyCmd represents the activateApiKey command
+var activateApiKeyCmd = &cobra.Command{
+	Use:   "activate-api-key [path-to-key]",
+	Short: "Activate an API key for use in following commands.",
+	Long: `Activates an API key for use in following commands by copying it to the
+configuration directory.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		auth.StoreCredentialsFile(args[0])
+	},
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -12,26 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package auth
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/infostellarinc/stellarcli/pkg/auth"
 )
 
-// activateApiKeyCmd represents the activateApiKey command
-var activateApiKeyCmd = &cobra.Command{
-	Use:   "activate-api-key [path-to-key]",
-	Short: "Activate an API key for use in following commands.",
-	Long: `Activates an API key for use in following commands by copying it to the
-configuration directory.`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		auth.StoreCredentialsFile(args[0])
-	},
+// authCmd represents the auth command
+var AuthCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Commands for authenticating the stellar tool.",
 }
 
 func init() {
-	authCmd.AddCommand(activateApiKeyCmd)
+	AuthCmd.AddCommand(activateApiKeyCmd)
 }

--- a/cmd/groundstation/groundStation.go
+++ b/cmd/groundstation/groundStation.go
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package groundstation
 
 import (
 	"github.com/spf13/cobra"
 )
 
 // gsCmd represents the satellite command
-var gsCmd = &cobra.Command{
+var GroundStationCmd = &cobra.Command{
 	Use:     "ground-station",
 	Aliases: []string{"gs"},
 	Short:   "Commands for working with ground stations",
 }
 
 func init() {
-	rootCmd.AddCommand(gsCmd)
+	GroundStationCmd.AddCommand(listGSPlansCmd)
 }

--- a/cmd/groundstation/listPlans.go
+++ b/cmd/groundstation/listPlans.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package groundstation
 
 import (
 	"fmt"
@@ -72,8 +72,6 @@ When run with default flags, plans in the next 31 days are returned.`,
 }
 
 func init() {
-	gsCmd.AddCommand(listGSPlansCmd)
-
 	listGSPlansCmd.Flags().StringVarP(&flgAOSAfter, "aos-after", "a", "",
 		`The start time (UTC) of the range of plans to list (inclusive). Example: "2006-01-02 15:04:00 (default current time"`)
 	listGSPlansCmd.Flags().StringVarP(&flgAOSBefore, "aos-before", "b", "",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/infostellarinc/stellarcli/cmd/auth"
+	"github.com/infostellarinc/stellarcli/cmd/groundstation"
+	"github.com/infostellarinc/stellarcli/cmd/satellite"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -51,6 +54,11 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/config/stellar/config.yaml)")
+
+	// Add sub commands
+	rootCmd.AddCommand(auth.AuthCmd)
+	rootCmd.AddCommand(groundstation.GroundStationCmd)
+	rootCmd.AddCommand(satellite.SatelliteCmd)
 }
 
 func initConfig() {

--- a/cmd/satellite/openStream.go
+++ b/cmd/satellite/openStream.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package satellite
 
 import (
 	"log"
@@ -61,8 +61,6 @@ the satellite and any incoming packets will be returned as is.
 }
 
 func init() {
-	satelliteCmd.AddCommand(openStreamCmd)
-
 	openStreamCmd.Flags().StringVarP(&mode, "mode", "m", "udp", "The proxy mode to use. One of [udp].")
 	openStreamCmd.Flags().StringVar(&listenHost, "listen-host", "127.0.0.1", "The host to listen for packets on.")
 	openStreamCmd.Flags().Uint16Var(&listenPort, "listen-port", 6000, "The port to listen for packets on.")

--- a/cmd/satellite/satellite.go
+++ b/cmd/satellite/satellite.go
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package satellite
 
 import (
 	"github.com/spf13/cobra"
 )
 
-// authCmd represents the auth command
-var authCmd = &cobra.Command{
-	Use:   "auth",
-	Short: "Commands for authenticating the stellar tool.",
+// satelliteCmd represents the satellite command
+var SatelliteCmd = &cobra.Command{
+	Use:   "satellite",
+	Short: "Commands for working with satellites",
 }
 
 func init() {
-	rootCmd.AddCommand(authCmd)
+	SatelliteCmd.AddCommand(openStreamCmd)
 }


### PR DESCRIPTION
- Moved sub commands to different directories for growth of commands. For example, listPlans will exist in both groundstation and satellite package.
- Changed commands so that they register child commands at parent's init function. Existing code need the modification because sub commands in different directory (package) won't be evaluated if no one call it explicitly. For example, auth.go add itself to rootCmd in its init function now. However, it won't be evaluated when moving it to a different package from rootCmd since no one use auth.go.