### PR TITLE
#34 Updated flag description of open-stream to be clearer.

### DIFF
--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -70,9 +70,9 @@ func NewOpenStreamCommand() *cobra.Command {
 
 	command.Flags().StringVarP(&mode, "mode", "m", "udp", "The proxy mode to use. One of [udp].")
 	command.Flags().StringVar(&listenHost, "listen-host", "127.0.0.1", "The host to listen for packets on.")
-	command.Flags().Uint16Var(&listenPort, "listen-port", 6000, "Stellar CLI listens packets to be sent to a satellite on this port.")
+	command.Flags().Uint16Var(&listenPort, "listen-port", 6000, "The port stellar listens for packets on. Packets on this port will be sent to the satellite.")
 	command.Flags().StringVar(&sendHost, "send-host", "127.0.0.1", "The host to send packets to. Only used by udp.")
-	command.Flags().Uint16Var(&sendPort, "send-port", 6001, "Stellar CLI send packets received from a satellite to this port.")
+	command.Flags().Uint16Var(&sendPort, "send-port", 6001, "The port stellar sends packets to. Packets from the satellite will be sent to this port.")
 
 	return command
 }

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -70,9 +70,9 @@ func NewOpenStreamCommand() *cobra.Command {
 
 	command.Flags().StringVarP(&mode, "mode", "m", "udp", "The proxy mode to use. One of [udp].")
 	command.Flags().StringVar(&listenHost, "listen-host", "127.0.0.1", "The host to listen for packets on.")
-	command.Flags().Uint16Var(&listenPort, "listen-port", 6000, "The port to listen for packets on.")
+	command.Flags().Uint16Var(&listenPort, "listen-port", 6000, "Stellar CLI listens packets to be sent to a satellite on this port.")
 	command.Flags().StringVar(&sendHost, "send-host", "127.0.0.1", "The host to send packets to. Only used by udp.")
-	command.Flags().Uint16Var(&sendPort, "send-port", 6001, "The port to send packets on. Only used by udp.")
+	command.Flags().Uint16Var(&sendPort, "send-port", 6001, "Stellar CLI send packets received from a satellite to this port.")
 
 	return command
 }


### PR DESCRIPTION
Current explanation of send and listen port of open-stream is not clear enough to understand which is used to receive packets from satellites. This PR aim to make it easy to understand which port is used for what purpose.

Fixes #34 