### PR TITLE
Upgraded gradle-golang-plugin to 0.0.15.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: openjdk:10-slim
+      - image: openjdk:11-slim
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,12 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "org.curioswitch.curiostack:gradle-golang-plugin:0.0.2"
+        classpath "org.curioswitch.curiostack:gradle-golang-plugin:0.0.15"
     }
 }
 
 plugins {
-    id 'com.github.breadmoirai.github-release' version '2.0.1'
+    id 'com.github.breadmoirai.github-release' version '2.2.4'
 }
 
 apply plugin: 'org.curioswitch.gradle-golang-plugin'
@@ -47,8 +47,3 @@ githubRelease {
 }
 
 tasks.githubRelease.dependsOn tasks.build
-
-wrapper {
-    gradleVersion = '4.10'
-    distributionType = 'ALL'
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR will fix the issue that the binary for windows are generated without ".exe" in its file name.