### PR TITLE
Set allowUploadToExisting flag to true for githubRelease plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ githubRelease {
     owner = 'infostellarinc'
     repo = 'stellarcli'
     releaseAssets = fileTree('build/zip')
+    allowUploadToExisting = true
 }
 
 tasks.githubRelease.dependsOn tasks.build


### PR DESCRIPTION
The github-release-gradle-plugin now needs allowUplaodToExisting flag set to true when it need to overwrite existing tag.
https://github.com/BreadMoirai/github-release-gradle-plugin/wiki#releaseAssets