### PR TITLE
Fixed to handle os.Interrupt correctly.

### DIFF
--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 
 	"github.com/spf13/cobra"
 
@@ -64,6 +65,7 @@ func NewOpenStreamCommand() *cobra.Command {
 			}
 
 			c := make(chan os.Signal)
+			signal.Notify(c, os.Interrupt)
 			defer close(c)
 
 			err := proxy.Start(o)


### PR DESCRIPTION
Current code doesn't catch os.Interrupt correctly resulting deferred functions not called.