### PR TITLE
Small refactoring to UDP proxy.

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -47,14 +47,14 @@ type satelliteStream struct {
 	conn        *grpc.ClientConn
 	streamId    string
 
-	recvChan           chan []byte
+	recvChan           chan<- []byte
 	recvLoopClosedChan chan struct{}
 
 	state uint32
 }
 
 // OpenSatelliteStream opens a stream to a satellite over the StellarStation API.
-func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan []byte) (SatelliteStream, error) {
+func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan<- []byte) (SatelliteStream, error) {
 	s := &satelliteStream{
 		satelliteId:        o.SatelliteID,
 		streamId:           "",


### PR DESCRIPTION
- Added direction to chan where possible to be strict.
- Moved recvBuf from struct member to function variable of recvLoop since it is only used in recvLoop.
- Renamed sendChan to streamChan because the word "send" is used for another meaning in the proxy.
- Changed to close UDP connections in the loop after receiving  in recvCloseChan to ensure closing order.
