### PR TITLE
Added framing flag to open-stream.

### DIFF
--- a/cmd/flag/framinig_flags.go
+++ b/cmd/flag/framinig_flags.go
@@ -1,0 +1,75 @@
+// Copyright © 2019 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/infostellarinc/go-stellarstation/api/v1"
+	"github.com/infostellarinc/stellarcli/cmd/util"
+)
+
+var (
+	// Supported framings.
+	availableFramings []string
+	// Default accepted framing.
+	defaultAcceptedFraming []string
+)
+
+type FramingFlags struct {
+	AcceptedFraming []string
+}
+
+// Add flags to the command.
+func (f *FramingFlags) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&f.AcceptedFraming, "accepted-framing", defaultAcceptedFraming,
+		"Framing type to receive. One of: "+strings.Join(availableFramings, "|"))
+}
+
+// Validate flag values.
+func (f *FramingFlags) Validate() error {
+	for _, framing := range f.AcceptedFraming {
+		if !util.Contains(availableFramings, framing) {
+			return fmt.Errorf("invalid framing type: %v. Expected one of : %v", framing,
+				strings.Join(availableFramings, "|"))
+		}
+	}
+
+	return nil
+}
+
+// Return accepted framing
+func (f *FramingFlags) ToProtoAcceptedFraming() []v1.Framing {
+	var acceptedFrame []v1.Framing
+	for _, framing := range f.AcceptedFraming {
+		acceptedFrame = append(acceptedFrame, v1.Framing(v1.Framing_value[framing]))
+	}
+
+	return acceptedFrame
+}
+
+// Create a new FramingFlags with default values set.
+func NewFramingFlags() *FramingFlags {
+	for value := range v1.Framing_value {
+		availableFramings = append(availableFramings, value)
+	}
+
+	return &FramingFlags{
+		AcceptedFraming: defaultAcceptedFraming,
+	}
+}

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -39,7 +39,8 @@ var (
 // Create open-stream command.
 func NewOpenStreamCommand() *cobra.Command {
 	proxyFlags := flag.NewProxyFlags()
-	flags := flag.NewFlagSet(proxyFlags)
+	framingFlags := flag.NewFramingFlags()
+	flags := flag.NewFlagSet(proxyFlags, framingFlags)
 
 	command := &cobra.Command{
 		Use:   openStreamUse,
@@ -61,7 +62,8 @@ func NewOpenStreamCommand() *cobra.Command {
 			defer proxy.Close()
 
 			o := &stream.SatelliteStreamOptions{
-				SatelliteID: args[0],
+				SatelliteID:     args[0],
+				AcceptedFraming: framingFlags.ToProtoAcceptedFraming(),
 			}
 
 			c := make(chan os.Signal)

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -32,7 +32,8 @@ const (
 )
 
 type SatelliteStreamOptions struct {
-	SatelliteID string
+	AcceptedFraming []stellarstation.Framing
+	SatelliteID     string
 }
 
 type SatelliteStream interface {
@@ -42,6 +43,8 @@ type SatelliteStream interface {
 }
 
 type satelliteStream struct {
+	acceptedFraming []stellarstation.Framing
+
 	satelliteId string
 	stream      stellarstation.StellarStationService_OpenSatelliteStreamClient
 	conn        *grpc.ClientConn
@@ -56,6 +59,7 @@ type satelliteStream struct {
 // OpenSatelliteStream opens a stream to a satellite over the StellarStation API.
 func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan<- []byte) (SatelliteStream, error) {
 	s := &satelliteStream{
+		acceptedFraming:    o.AcceptedFraming,
 		satelliteId:        o.SatelliteID,
 		streamId:           "",
 		recvChan:           recvChan,
@@ -139,8 +143,9 @@ func (ss *satelliteStream) openStream() error {
 	}
 
 	req := stellarstation.SatelliteStreamRequest{
-		SatelliteId: ss.satelliteId,
-		StreamId:    ss.streamId,
+		AcceptedFraming: ss.acceptedFraming,
+		SatelliteId:     ss.satelliteId,
+		StreamId:        ss.streamId,
 	}
 
 	err = stream.Send(&req)


### PR DESCRIPTION
By the PR, users can specify accepted_framing from --accepted-framing flag. Default behavior won't change by this change.
Example.
./stellar sat open-stream --accepted-framing IQ,BITSTREAM 98