### PR TITLE
Changed the port of TCP proxy to be consistent with UDP proxy.

### DIFF
--- a/cmd/flag/proxy_flags.go
+++ b/cmd/flag/proxy_flags.go
@@ -43,7 +43,7 @@ var (
 	// Default listen host for TCP.
 	defaultTCPListenHost = "127.0.0.1"
 	// Default listen port for TCP.
-	defaultTCPListenPort uint16 = 6000
+	defaultTCPListenPort uint16 = 6001
 )
 
 type ProxyFlags struct {


### PR DESCRIPTION
Currently, UDP Proxy uses 6001 as the sending port to which the stellar command send packets from the satellite. Although the port of TCP proxy is used for both sending and receiving data, it is convenient for users to be able to use the same port for listening data with the one in UDP proxy, 6001.