### PR TITLE
Added verbose flag to list-passes.

### DIFF
--- a/cmd/satellite/list_passes.go
+++ b/cmd/satellite/list_passes.go
@@ -33,7 +33,8 @@ var (
 func NewListAvailablePassesCommand() *cobra.Command {
 	outputFormatFlags := flag.NewOutputFormatFlags()
 	minElevationFlags := flag.NewMinElevationFlags()
-	flags := flag.NewFlagSet(outputFormatFlags, minElevationFlags)
+	verboseFlag := flag.NewVerboseFlags()
+	flags := flag.NewFlagSet(outputFormatFlags, minElevationFlags, verboseFlag)
 
 	command := &cobra.Command{
 		Use:   listAvailablePassesUse,
@@ -56,6 +57,7 @@ func NewListAvailablePassesCommand() *cobra.Command {
 				Printer:      p,
 				ID:           args[0],
 				MinElevation: minElevationFlags.MinElevation,
+				IsVerbose:    verboseFlag.IsVerbose,
 			}
 
 			pass.ListAvailablePasses(o)

--- a/cmd/util/map.go
+++ b/cmd/util/map.go
@@ -1,0 +1,24 @@
+// Copyright © 2019 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+// Converts map and keys to a slice.
+func MapToSlice(m map[interface{}]interface{}, keys []interface{}) []interface{} {
+	result := make([]interface{}, len(keys))
+	for i, header := range keys {
+		result[i] = m[header]
+	}
+	return result
+}


### PR DESCRIPTION
Added the verbose flag to list-passes so that it only shows important values such as when and where the satellite will have passes.  Reservation tokens required to reserve passes will not be displayed by default with this change. You can get the reservation token and other values by adding -v flag.