### PR TITLE
Fixed the issue that error from openStream is ignored.

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -70,9 +70,9 @@ func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan<- []byte) (Sat
 		isVerbose:          o.IsVerbose,
 	}
 
-	s.start()
+	err := s.start()
 
-	return s, nil
+	return s, err
 }
 
 // Send sends a packet to the satellite.


### PR DESCRIPTION
The stream.go doesn't return error even when it received error from OpenStream which could return error when it fails to connect to API server.