### PR TITLE
Fixed not to retry infinitely on errors executing recv.

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -126,10 +126,9 @@ func (ss *satelliteStream) recvLoop() {
 					return err
 				}
 
-				var recvErr error
 				response, err := ss.stream.Recv()
-				if recvErr != nil {
-					return recvErr
+				if err != nil {
+					return err
 				}
 				res = response
 


### PR DESCRIPTION
The current logic retries openStream infinitely when it succeeded to connect to the API stream but failed on Recv. This happens when API key is revoked. The new logic in this PR ensures retry stops for the case.