### PR TITLE
Changed to show sent data size with verbose flag.

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -97,7 +97,7 @@ func (ss *satelliteStream) Send(payload []byte) error {
 		},
 	}
 
-	if ss.isDebug {
+	if ss.isVerbose {
 		log.Printf("sent data: size: %d bytes\n", len(payload))
 	}
 


### PR DESCRIPTION
Since transmission packets won't happen very frequently, it can be printed by verbose flag.