### PR TITLE
Fixed nil pointer error when RadioDevice is nil.

### DIFF
--- a/pkg/groundstation/plan/list_plans.go
+++ b/pkg/groundstation/plan/list_plans.go
@@ -88,12 +88,19 @@ func ListPlans(o *ListOptions) {
 			log.Fatal(err)
 		}
 
+		var downlinkFreq, uplinkFreq uint64
+		if plan.DownlinkRadioDevice != nil {
+			downlinkFreq = plan.DownlinkRadioDevice.CenterFrequencyHz
+		}
+		if plan.UplinkRadioDevice != nil {
+			uplinkFreq = plan.UplinkRadioDevice.CenterFrequencyHz
+		}
 		record := []interface{}{
 			plan.PlanId,
 			aos,
 			los,
-			plan.DownlinkRadioDevice.CenterFrequencyHz,
-			plan.UplinkRadioDevice.CenterFrequencyHz,
+			downlinkFreq,
+			uplinkFreq,
 			plan.Tle.Line_1,
 			plan.Tle.Line_2,
 		}


### PR DESCRIPTION
Fix the error that the list-plans command for GroundStations fails when DownlinkRadioDevice or UplinkRadioDevice is nil.