### PR TITLE
Changed sorting logic of packet ordering

### DIFF
--- a/cmd/flag/correct_order_flags.go
+++ b/cmd/flag/correct_order_flags.go
@@ -23,31 +23,21 @@ import (
 
 var (
 	// Default correct order.
-	defaultCorrectOrder = false
-
-	defaultBundleCountThreshold               = 20
-	defaultBundleByteThreshold  int           = 10e6 // 1M
-	defaultDelayThreshold       time.Duration = 500 * time.Millisecond
+	defaultCorrectOrder                 = false
+	defaultDelayThreshold time.Duration = 500 * time.Millisecond
 )
 
 type CorrectOrderFlags struct {
-	CorrectOrder bool
-
-	BundleCountThreshold int
-	BundleByteThreshold  int
-	DelayThreshold       time.Duration
+	CorrectOrder   bool
+	DelayThreshold time.Duration
 }
 
 // Add flags to the command.
 func (f *CorrectOrderFlags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVarP(&f.DelayThreshold, "delay-threshold", "", defaultDelayThreshold,
 		"The maximum amount of time that packets remain in the sorting pool.")
-	cmd.Flags().IntVarP(&f.BundleCountThreshold, "count-threshold", "", defaultBundleCountThreshold,
-		"The maximum number of packets in the sorting pool.")
-	cmd.Flags().IntVarP(&f.BundleByteThreshold, "byte-threshold", "", defaultBundleByteThreshold,
-		"The maximum size of the sorting pool in bytes.")
 	cmd.Flags().BoolVarP(&f.CorrectOrder, "correct-order", "", defaultCorrectOrder,
-		"When set to true, packets will be sorted by time_first_byte_received.")
+		"When set to true, packets will be sorted by time_first_byte_received. This feature is alpha quality.")
 }
 
 // Validate flag values.

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -72,8 +72,8 @@ func NewOpenStreamCommand() *cobra.Command {
 				IsDebug:         debugFlag.IsDebug,
 				IsVerbose:       verboseFlag.IsVerbose,
 
-				CorrectOrder:         correctOrderFlags.CorrectOrder,
-				DelayThreshold:       correctOrderFlags.DelayThreshold,
+				CorrectOrder:   correctOrderFlags.CorrectOrder,
+				DelayThreshold: correctOrderFlags.DelayThreshold,
 			}
 
 			c := make(chan os.Signal)

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -73,8 +73,6 @@ func NewOpenStreamCommand() *cobra.Command {
 				IsVerbose:       verboseFlag.IsVerbose,
 
 				CorrectOrder:         correctOrderFlags.CorrectOrder,
-				BundleCountThreshold: correctOrderFlags.BundleCountThreshold,
-				BundleByteThreshold:  correctOrderFlags.BundleByteThreshold,
 				DelayThreshold:       correctOrderFlags.DelayThreshold,
 			}
 

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -158,7 +158,7 @@ func (ss *satelliteStream) recvLoop() {
 		// Flush data in the PriorityQueue half of the incoming data.
 		numFlush := (pq.Len() + 1) / 2
 		if numFlush > 0 {
-			log.Printf("%d data in the queue, flused %d.\n", pq.Len(), numFlush)
+			log.Printf("%d data in the queue, flushed %d.\n", pq.Len(), numFlush)
 		}
 
 		// Flush half of the data in the priority queue

--- a/pkg/util/collection/collection_suite_test.go
+++ b/pkg/util/collection/collection_suite_test.go
@@ -1,0 +1,28 @@
+//
+// Copyright © 2019 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collection
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCollection(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Collection Suite")
+}

--- a/pkg/util/collection/priority_queue.go
+++ b/pkg/util/collection/priority_queue.go
@@ -25,7 +25,7 @@ type pqInternal struct {
 	items []interface{}
 	less  func(i, j interface{}) bool
 
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 // A PriorityQueue that returns items ordered by 'less' function.
@@ -34,9 +34,17 @@ type PriorityQueue struct {
 	queue *pqInternal
 }
 
-func (pq *pqInternal) Len() int { return len(pq.items) }
+func (pq *pqInternal) Len() int {
+	pq.mu.RLock()
+	defer pq.mu.RUnlock()
+
+	return len(pq.items)
+}
 
 func (pq *pqInternal) Less(i, j int) bool {
+	pq.mu.RLock()
+	defer pq.mu.RUnlock()
+
 	return pq.less(pq.items[i], pq.items[j])
 }
 

--- a/pkg/util/collection/priority_queue.go
+++ b/pkg/util/collection/priority_queue.go
@@ -1,0 +1,90 @@
+//
+// Copyright © 2019 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collection
+
+import (
+	"container/heap"
+	"sync"
+)
+
+// An internal type of PriorityQueue that implements heap.Interface.
+type pqInternal struct {
+	items []interface{}
+	less  func(i, j interface{}) bool
+
+	mu sync.Mutex
+}
+
+// A PriorityQueue that returns items ordered by 'less' function.
+// This type IS NOT thread safe.
+type PriorityQueue struct {
+	queue *pqInternal
+}
+
+func (pq *pqInternal) Len() int { return len(pq.items) }
+
+func (pq *pqInternal) Less(i, j int) bool {
+	return pq.less(pq.items[i], pq.items[j])
+}
+
+func (pq *pqInternal) Pop() interface{} {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	if len(pq.items) == 0 {
+		return nil
+	}
+
+	n := len(pq.items)
+	item := pq.items[n-1]
+	pq.items[n-1] = nil
+	pq.items = pq.items[0 : n-1]
+	return item
+}
+
+func (pq *pqInternal) Push(item interface{}) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	if item == nil {
+		panic("cannot push nil.")
+	}
+
+	pq.items = append(pq.items, item)
+}
+
+func (pq *pqInternal) Swap(i, j int) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
+}
+
+func (pq *PriorityQueue) Len() int { return pq.queue.Len() }
+
+func (pq *PriorityQueue) Pop() interface{} {
+	return heap.Pop(pq.queue)
+}
+
+func (pq *PriorityQueue) Push(item interface{}) {
+	heap.Push(pq.queue, item)
+}
+
+func NewPriorityQueue(itemExample interface{}, less func(i, j interface{}) bool) *PriorityQueue {
+	return &PriorityQueue{
+		queue: &pqInternal{items: make([]interface{}, 0), less: less},
+	}
+}

--- a/pkg/util/collection/priority_queue_test.go
+++ b/pkg/util/collection/priority_queue_test.go
@@ -1,0 +1,95 @@
+//
+// Copyright © 2019 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collection
+
+import (
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type Item struct {
+	t time.Time
+}
+
+var _ = Describe("PriorityQueue", func() {
+	Context("when called without any items", func() {
+		pq := NewPriorityQueue((*int)(nil), func(i, j interface{}) bool {
+			int1 := i.(*int)
+			int2 := i.(*int)
+			return *int1 < *int2
+		})
+
+		It("Len() should return", func() {
+			Expect(pq.Len()).Should(Equal(0))
+		})
+		It("Pop() should panic", func() {
+			Expect(func() {
+				pq.Pop()
+			}).To(Panic())
+		})
+	})
+
+	Context("when passed items", func() {
+		pq := NewPriorityQueue((*Item)(nil), func(i, j interface{}) bool {
+			item1 := i.(*Item)
+			item2 := j.(*Item)
+
+			return item1.t.Before(item2.t)
+		})
+
+		It("should succeed", func() {
+			rand.Seed(time.Now().UnixNano())
+
+			n := 50
+			for i := 0; i < n; i++ {
+				nsec := rand.Intn(1000)
+				seconds := rand.Intn(30)
+				item := &Item{t: time.Date(2019, 10, 01, 3, 16, seconds, nsec, time.UTC)}
+				pq.Push(item)
+			}
+
+			items := make([]*Item, n)
+			for i := 0; i < n; i++ {
+				Expect(pq.Len()).Should(Equal(n - i))
+				item := pq.Pop().(*Item)
+				items[i] = item
+			}
+
+			for i := 1; i < n; i++ {
+				// Test if items[i-1].t is equal or before items[i]
+				Expect(!items[i-1].t.After(items[i].t)).Should(BeTrue())
+			}
+		})
+	})
+
+	Context("when nil is passed to Push()", func() {
+		pq := NewPriorityQueue((*Item)(nil), func(i, j interface{}) bool {
+			item1 := i.(*Item)
+			item2 := j.(*Item)
+
+			return item1.t.Before(item2.t)
+		})
+
+		It("should panic", func() {
+			Expect(func() {
+				pq.Push(nil)
+			}).To(Panic())
+		})
+	})
+})


### PR DESCRIPTION
The current sorting logic has an issue that data in the edge of the queue will not be sorted correctly. In order to improve it, this code store data in a priority queue and flush half of the data in every delayThreshold.