### PR TITLE
Added the resume functionality to open-stream command

### DIFF
--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -1,0 +1,39 @@
+//
+// Copyright © 2019 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type OpenStreamFlag struct {
+	StreamId string
+}
+
+// Add a flag to the command.
+func (f *OpenStreamFlag) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.StreamId, "stream-id", "r", "", "The StreamId to resume.")
+}
+
+// Validate flag values.
+func (f *OpenStreamFlag) Validate() error {
+	return nil
+}
+
+// Create a new OpenStreamFlag with default values set.
+func NewOpenStreamFlag() *OpenStreamFlag {
+	return &OpenStreamFlag{}
+}

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -41,10 +41,11 @@ func NewOpenStreamCommand() *cobra.Command {
 	debugFlag := flag.NewDebugFlag()
 	correctOrderFlags := flag.NewCorrectOrderFlags()
 	framingFlags := flag.NewFramingFlags()
+	openStreamFlag := flag.NewOpenStreamFlag()
 	planIdFlag := flag.NewPlanIdFlag()
 	proxyFlags := flag.NewProxyFlags()
 	verboseFlag := flag.NewVerboseFlags()
-	flags := flag.NewFlagSet(correctOrderFlags, debugFlag, framingFlags, planIdFlag, proxyFlags, verboseFlag)
+	flags := flag.NewFlagSet(correctOrderFlags, debugFlag, framingFlags, openStreamFlag, planIdFlag, proxyFlags, verboseFlag)
 
 	command := &cobra.Command{
 		Use:   openStreamUse,
@@ -69,6 +70,7 @@ func NewOpenStreamCommand() *cobra.Command {
 				SatelliteID:     args[0],
 				AcceptedFraming: framingFlags.ToProtoAcceptedFraming(),
 				AcceptedPlanId:  planIdFlag.AcceptedPlanId,
+				StreamId:        openStreamFlag.StreamId,
 				IsDebug:         debugFlag.IsDebug,
 				IsVerbose:       verboseFlag.IsVerbose,
 

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -15,7 +15,7 @@ stellar satellite open-stream [satellite-id] [flags]
 ### Options
 
 ```
-      --accepted-framing strings   Framing type to receive. One of: FREE_TEXT_UTF8|WATERFALL|BITSTREAM|AX25|IQ|IMAGE_PNG|IMAGE_JPEG
+      --accepted-framing strings   Framing type to receive. One of: WATERFALL|BITSTREAM|AX25|IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8
       --accepted-plan-id strings   Plan ID(s) to accept data from.
       --correct-order              When set to true, packets will be sorted by time_first_byte_received. This feature is alpha quality.
       --debug                      Output debug information. (default false)
@@ -26,6 +26,7 @@ stellar satellite open-stream [satellite-id] [flags]
       --proxy string               Proxy protocol. One of: udp|tcp (default "udp")
       --send-host string           Deprecated: use udp-send-host instead.
       --send-port uint16           Deprecated: use udp-send-port instead.
+  -r, --stream-id string           The StreamId to resume.
       --tcp-listen-host string     The host to listen for TCP connection on. (default "127.0.0.1")
       --tcp-listen-port uint16     The port used to communicate with satellite. Clients can receive and send data through the port. (default 6001)
       --udp-listen-host string     The host to listen for packets on. (default "127.0.0.1")

--- a/pkg/apiclient/conn.go
+++ b/pkg/apiclient/conn.go
@@ -16,6 +16,7 @@ package apiclient
 
 import (
 	"crypto/tls"
+	"log"
 	"os"
 	"strings"
 
@@ -36,6 +37,7 @@ func Dial() (*grpc.ClientConn, error) {
 	if len(apiUrl) == 0 {
 		apiUrl = "api.stellarstation.com:443"
 	}
+	log.Printf("API endpoint: %s", apiUrl)
 
 	tlsConfig := &tls.Config{}
 	if strings.HasPrefix(apiUrl, "localhost") || strings.HasPrefix(apiUrl, "127.0.0.1") {

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -43,6 +43,7 @@ type SatelliteStreamOptions struct {
 	AcceptedFraming []stellarstation.Framing
 	AcceptedPlanId  []string
 	SatelliteID     string
+	StreamId        string
 	IsDebug         bool
 	IsVerbose       bool
 
@@ -83,7 +84,7 @@ func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan<- []byte) (Sat
 	s := &satelliteStream{
 		acceptedFraming:    o.AcceptedFraming,
 		satelliteId:        o.SatelliteID,
-		streamId:           "",
+		streamId:           o.StreamId,
 		recvChan:           recvChan,
 		state:              OPEN,
 		recvLoopClosedChan: make(chan struct{}),
@@ -215,7 +216,7 @@ func (ss *satelliteStream) recvLoop() {
 			telemetry := res.GetReceiveTelemetryResponse().Telemetry
 			payload := telemetry.Data
 			if ss.isDebug {
-				log.Printf("received data: planId: %s, framing type: %s, size: %d bytes\n", planId, telemetry.Framing, len(payload))
+				log.Printf("received data: streamId: %v, planId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetry.Framing, len(payload))
 			}
 			if ss.correctOrder {
 				go func() {


### PR DESCRIPTION
Added a command line option in open-stream command so that the CLI can resume the stream. The stream ID is printed when you add `-v` option.