### PR TITLE
--stats doesn't show the latest update after telemetry stopped

### DIFF
--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,34 @@
+// Copyright © 2020 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+// run with "go test -v" in this folder to see output
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestThrottle(t *testing.T) {
+	SetEmitRateMillis(500)
+	for i := 0; i < 100; i++ {
+		PrintlnThrottled("%d", i)
+		time.Sleep(time.Duration(10) * time.Millisecond)
+	}
+	// manually make sure last message is printed
+	fmt.Println("(99 should be printed below this line)")
+	time.Sleep(time.Duration(600) * time.Millisecond)
+}

--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -182,11 +182,9 @@ func duration(start, end *timestamp.Timestamp) string {
 
 func (metrics *MetricsCollector) logReport() {
 	if metrics.totalMessagesReceived > 0 {
-		// create newline incase logger is in overwrite mode
+		// Dont use metrics.logger because it might be in overwrite mode
 		logger := fmt.Printf
-		metrics.logStats()
 		logger("\n\n")
-
 		logger("[STATS] %s, Pass summary:\n", time.Now().Format("20060102 15:04:05"))
 		logger("\n")
 		logger("  Plan ID   : %s\n", metrics.planId)
@@ -205,13 +203,6 @@ func (metrics *MetricsCollector) logReport() {
 		logger("  Average rate (bits/s) : %sbps\n", humanReadableCountSI(metrics.avgRate()))
 		logger("  Average delay         : %s\n", humanReadableNanoSeconds(metrics.avgDelay()))
 		logger("\n\n")
-
-		// display report
-		avgDelayNanos := humanReadableNanoSeconds(metrics.avgDelay())
-		rateStr := humanReadableCountSI(metrics.avgRate())
-		size := humanReadableBytes(metrics.totalBytesReceived)
-		logger("[STATS] %s, plan_id: %s, [DATA] %5d msgs, bytes: %s, rate: %sbps, delay: %s",
-			time.Now().Format("2006/01/02 15:04:05"), metrics.planId, metrics.totalMessagesReceived, size, rateStr, avgDelayNanos)
 	}
 }
 

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -316,7 +316,7 @@ func (ss *satelliteStream) start() (func(), error) {
 	// metric collector for data rate, total received size, etc
 	if ss.showStats {
 		if ss.isVerbose || ss.isDebug {
-			metrics = *NewMetricsCollector(log.InfoThrottled)
+			metrics = *NewMetricsCollector(log.PrintlnThrottled)
 		} else {
 			metrics = *NewMetricsCollector(log.LastLine)
 		}


### PR DESCRIPTION
- address `--stats` doesn't show the latest update after telemetry stopped
- remove logger methods not used and not well tested
- remove unnecessary info printed during pass report
- change default log throttling rate from 500ms to 2000ms