### PR TITLE
disable antenna messages for stats

### DIFF
--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -191,7 +191,7 @@ func duration(start, end *timestamp.Timestamp) string {
 }
 
 func (metrics *MetricsCollector) logReport() {
-	if metrics.totalMessagesReceived >= 0 {
+	if metrics.totalMessagesReceived > 0 {
 		// Dont use metrics.logger because it might be in overwrite mode
 		logger := fmt.Printf
 		logger("\n\n")
@@ -221,8 +221,8 @@ func (metrics *MetricsCollector) logStats() {
 	iDelayNanos := humanReadableNanoSeconds(metrics.instantDelay())
 	iRateStr := humanReadableCountSI(metrics.instantRate())
 	size := humanReadableBytes(metrics.totalBytesReceived)
-	metrics.logger("[STATS] %s, plan_id: %s, azm: %5.2f, ele: %5.1f, freq: %5.1f MHz [DATA] %3d msgs, bytes: %9v, rate: %9vbps, delay: %9v",
-		time.Now().Format("20060102 15:04:05"), metrics.planId, metrics.azimuth, metrics.elevation, metrics.frequency, metrics.totalMessagesReceived, size, iRateStr, iDelayNanos)
+	metrics.logger("[STATS] %s, plan_id: %s, %3d msgs, bytes: %9v, rate: %9vbps, delay: %9v",
+		time.Now().Format("20060102 15:04:05"), metrics.planId, metrics.totalMessagesReceived, size, iRateStr, iDelayNanos)
 }
 
 // return avg rate for entire plan

--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -191,7 +191,7 @@ func duration(start, end *timestamp.Timestamp) string {
 }
 
 func (metrics *MetricsCollector) logReport() {
-	if metrics.totalMessagesReceived > 0 {
+	if metrics.totalMessagesReceived >= 0 {
 		// Dont use metrics.logger because it might be in overwrite mode
 		logger := fmt.Printf
 		logger("\n\n")

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -218,6 +218,9 @@ func (ss *satelliteStream) recvLoop() {
 		switch res.Response.(type) {
 		case *stellarstation.SatelliteStreamResponse_ReceiveTelemetryResponse:
 			planId := res.GetReceiveTelemetryResponse().PlanId
+			if ss.showStats {
+				metrics.setPlanId(planId)
+			}
 			if len(ss.acceptedPlanId) != 0 && !util.Contains(ss.acceptedPlanId, planId) {
 				break
 			}
@@ -239,9 +242,6 @@ func (ss *satelliteStream) recvLoop() {
 			}
 		case *stellarstation.SatelliteStreamResponse_StreamEvent:
 			planId := res.GetStreamEvent().GetPlanMonitoringEvent().PlanId
-			if ss.showStats {
-				metrics.setPlanId(planId) // reset statistics when new plan detected
-			}
 			if len(ss.acceptedPlanId) != 0 && !util.Contains(ss.acceptedPlanId, planId) {
 				break
 			}

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -218,9 +218,6 @@ func (ss *satelliteStream) recvLoop() {
 		switch res.Response.(type) {
 		case *stellarstation.SatelliteStreamResponse_ReceiveTelemetryResponse:
 			planId := res.GetReceiveTelemetryResponse().PlanId
-			// if ss.showStats {
-			// 	metrics.setPlanId(planId)
-			// }
 			if len(ss.acceptedPlanId) != 0 && !util.Contains(ss.acceptedPlanId, planId) {
 				break
 			}
@@ -249,20 +246,14 @@ func (ss *satelliteStream) recvLoop() {
 				break
 			}
 
-			if ss.isVerbose || ss.showStats {
+			if ss.isVerbose {
 				if gsState := res.GetStreamEvent().GetPlanMonitoringEvent().GetGroundStationState(); gsState != nil {
 					if a := gsState.Antenna; a != nil {
 						log.Verbose("planId: %v, azimuth: %v, elevation: %v\n", planId, a.Azimuth.Measured, a.Elevation.Measured)
-						// if ss.showStats {
-						// 	metrics.collectAntenna(a.Azimuth.Measured, a.Elevation.Measured)
-						// }
 					}
 
 					if rcv := gsState.Receiver; rcv != nil {
 						log.Verbose("central frequency (MHz): %.2f\n", float64(gsState.Receiver.CenterFrequencyHz)/1e6)
-						// if ss.showStats {
-						// 	metrics.collectReceiver(float64(gsState.Receiver.CenterFrequencyHz) / 1e6)
-						// }
 					}
 				}
 

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -218,9 +218,9 @@ func (ss *satelliteStream) recvLoop() {
 		switch res.Response.(type) {
 		case *stellarstation.SatelliteStreamResponse_ReceiveTelemetryResponse:
 			planId := res.GetReceiveTelemetryResponse().PlanId
-			if ss.showStats {
-				metrics.setPlanId(planId)
-			}
+			// if ss.showStats {
+			// 	metrics.setPlanId(planId)
+			// }
 			if len(ss.acceptedPlanId) != 0 && !util.Contains(ss.acceptedPlanId, planId) {
 				break
 			}
@@ -253,16 +253,16 @@ func (ss *satelliteStream) recvLoop() {
 				if gsState := res.GetStreamEvent().GetPlanMonitoringEvent().GetGroundStationState(); gsState != nil {
 					if a := gsState.Antenna; a != nil {
 						log.Verbose("planId: %v, azimuth: %v, elevation: %v\n", planId, a.Azimuth.Measured, a.Elevation.Measured)
-						if ss.showStats {
-							metrics.collectAntenna(a.Azimuth.Measured, a.Elevation.Measured)
-						}
+						// if ss.showStats {
+						// 	metrics.collectAntenna(a.Azimuth.Measured, a.Elevation.Measured)
+						// }
 					}
 
 					if rcv := gsState.Receiver; rcv != nil {
 						log.Verbose("central frequency (MHz): %.2f\n", float64(gsState.Receiver.CenterFrequencyHz)/1e6)
-						if ss.showStats {
-							metrics.collectReceiver(float64(gsState.Receiver.CenterFrequencyHz) / 1e6)
-						}
+						// if ss.showStats {
+						// 	metrics.collectReceiver(float64(gsState.Receiver.CenterFrequencyHz) / 1e6)
+						// }
 					}
 				}
 


### PR DESCRIPTION
- `--stats` now ignores antenna messages so that pass reports will not be generates if antenna messages have different plan id
- `--stats` now always shows pass report on ctrl-c even if no telemetry data received