### PR TITLE
add checks for invalid pointers and arithmetic

### DIFF
--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -27,7 +27,7 @@ import (
 const InstantMinSamples = 5
 
 // InstantMaxSamples - Maximum number of samples to calculate instantaneous stats with (rate & delay)
-const InstantMaxSamples = 10000
+const InstantMaxSamples = 50000
 
 // InstantSampleSeconds - Duration of data samples to calculate instantaneous stats with
 const InstantSampleSeconds = 10

--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -30,7 +30,7 @@ const InstantMinSamples = 5
 const InstantMaxSamples = 1000
 
 // InstantSampleSeconds - Duration of data samples to calculate instantaneous stats with
-const InstantSampleSeconds = 5
+const InstantSampleSeconds = 10
 
 type telemetryWithTimestamp struct {
 	ReceivedTime         time.Time

--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -27,7 +27,7 @@ import (
 const InstantMinSamples = 5
 
 // InstantMaxSamples - Maximum number of samples to calculate instantaneous stats with (rate & delay)
-const InstantMaxSamples = 1000
+const InstantMaxSamples = 10000
 
 // InstantSampleSeconds - Duration of data samples to calculate instantaneous stats with
 const InstantSampleSeconds = 10

--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -124,7 +124,7 @@ func (metrics *MetricsCollector) collectTelemetry(telemetry *stellarstation.Tele
 		metrics.writeLock.Lock()
 		metrics.messageBuffer = append(metrics.messageBuffer, msg)
 
-		// Keep 5 seconds worth of samples, but no less than InstantMinSamples samples, and no more than InstantMaxSamples; remove oldest sample if:
+		// Keep 10 seconds worth of samples, but no less than InstantMinSamples samples, and no more than InstantMaxSamples; remove oldest sample if:
 		// 1. list larger than InstantMinSamples && oldest sample is older than "now - InstantSampleSeconds"
 		// 2. list larger than InstantMaxSamples
 		for (len(metrics.messageBuffer) > InstantMinSamples && metrics.messageBuffer[0].ReceivedTime.UnixNano() < time.Now().UnixNano()-(InstantSampleSeconds*1e9)) ||

--- a/pkg/satellite/stream/metrics_collector_test.go
+++ b/pkg/satellite/stream/metrics_collector_test.go
@@ -40,10 +40,11 @@ func TestMetricLogging(t *testing.T) {
 	metrics.setPlanId("plan1")
 	for i := 1; i <= 10e17; i *= 4 {
 		metrics.collectMessage(i)
-		t := time.Now().Add(-time.Duration(i) * time.Millisecond)
+		t := time.Now().Add(-time.Duration(i) * time.Nanosecond)
 		metrics.collectTelemetry(&stellarstation.Telemetry{
-			Data:                 make([]byte, 5, 5),
-			TimeLastByteReceived: ToTimestamp(&t),
+			Data:                  make([]byte, 5, 5),
+			TimeFirstByteReceived: ToTimestamp(&t),
+			TimeLastByteReceived:  ToTimestamp(&t),
 		})
 		metrics.logStats()
 		time.Sleep(time.Millisecond * time.Duration(50))


### PR DESCRIPTION
- add nil checks anywhere I can see that could potentially cause NPE
- add synchronization locks when reading and manipulating stats samples
- increase sample data retention for `--stats` to 10 seconds (for large chunks & slow data rate), note that at least 2 chucks must be received within this window for instantaneous rate to display correctly
- add check for firstByteTimstamp and lastByteTimestamp to address negative duration issue.

```
[STATS] 20200512 09:35:51, plan_id: 158924343, 19729 msgs, bytes:  19.7 MiB, rate:   795.7 kbps, delay:    5.0 m  panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x145c4b0]

goroutine 8 [running]:
github.com/infostellarinc/stellarcli/pkg/satellite/stream.(*MetricsCollector).instantDelay(0x1a05380, 0xc000067f28)
	/Users/xxx/git/stellarcli/pkg/satellite/stream/metrics_collector.go:243 +0xf0
github.com/infostellarinc/stellarcli/pkg/satellite/stream.(*MetricsCollector).logStats(0x1a05380)
	/Users/xxx/git/stellarcli/pkg/satellite/stream/metrics_collector.go:221 +0x40
github.com/infostellarinc/stellarcli/pkg/satellite/stream.(*MetricsCollector).startStatsEmitSchedulerWorker(0x1a05380, 0x1f4)
	/Users/xxx/git/stellarcli/pkg/satellite/stream/metrics_collector.go:347 +0xd1
created by github.com/infostellarinc/stellarcli/pkg/satellite/stream.(*MetricsCollector).StartStatsEmitScheduler
	/Users/xxx/git/stellarcli/pkg/satellite/stream/metrics_collector.go:357 +0x49
```