### PR TITLE
Only show stats log when plan id exists

### DIFF
--- a/pkg/satellite/stream/metrics_collector.go
+++ b/pkg/satellite/stream/metrics_collector.go
@@ -221,8 +221,10 @@ func (metrics *MetricsCollector) logStats() {
 	iDelayNanos := humanReadableNanoSeconds(metrics.instantDelay())
 	iRateStr := humanReadableCountSI(metrics.instantRate())
 	size := humanReadableBytes(metrics.totalBytesReceived)
-	metrics.logger("[STATS] %s, plan_id: %s, %3d msgs, bytes: %9v, rate: %9vbps, delay: %9v",
-		time.Now().Format("20060102 15:04:05"), metrics.planId, metrics.totalMessagesReceived, size, iRateStr, iDelayNanos)
+	if metrics.planId != "" {
+		metrics.logger("[STATS] %s, plan_id: %s, %3d msgs, bytes: %9v, rate: %9vbps, delay: %9v",
+			time.Now().Format("20060102 15:04:05"), metrics.planId, metrics.totalMessagesReceived, size, iRateStr, iDelayNanos)
+	}
 }
 
 // return avg rate for entire plan


### PR DESCRIPTION
In order to eliminate some log spam when you first start the stream connection
i.e. `[STATS] 20200513 14:41:58, plan_id: ,   0 msgs, bytes:       0 B, rate:        0 bps, delay:      0 ns`