### PR TITLE
Display telemetry metadata for list-plans if verbose is true

### DIFF
--- a/cmd/flag/output_format_flags.go
+++ b/cmd/flag/output_format_flags.go
@@ -56,11 +56,18 @@ func (f *OutputFormatFlags) Validate() error {
 }
 
 // Return a Printer corresponding to the output format.
-func (f *OutputFormatFlags) ToPrinter() printer.Printer {
+func (f *OutputFormatFlags) ToPrinter(FlagsOn ...bool) printer.Printer {
 	format := util.ToLower(f.Format)
 
 	switch format {
 	case "wide":
+		isVerbose := len(FlagsOn) > 0 && FlagsOn[0]
+		if isVerbose {
+			log.Println("wide format not supported when verbose flag is on")
+			o := printer.NewJSONPrinterOptions(defaultOutput)
+			return printer.NewJSONPrinter(o)
+		}
+
 		o := printer.NewWidePrinterOptions(defaultOutput)
 		return printer.NewWidePrinter(o)
 	case "csv":

--- a/cmd/flag/verbose_flags.go
+++ b/cmd/flag/verbose_flags.go
@@ -22,7 +22,7 @@ type VerboseFlags struct {
 
 // Add flags to the command.
 func (f *VerboseFlags) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&f.IsVerbose, "verbose", "v", false, "Output more information. (default false)")
+	cmd.Flags().BoolVarP(&f.IsVerbose, "verbose", "v", false, "Output more information in JSON format. (default false)")
 }
 
 // Validate flag values.

--- a/cmd/flag/verbose_flags.go
+++ b/cmd/flag/verbose_flags.go
@@ -14,7 +14,10 @@
 
 package flag
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"strings"
+)
 
 type VerboseFlags struct {
 	IsVerbose bool
@@ -22,7 +25,11 @@ type VerboseFlags struct {
 
 // Add flags to the command.
 func (f *VerboseFlags) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&f.IsVerbose, "verbose", "v", false, "Output more information in JSON format. (default false)")
+	message := "Output more information in JSON format. (default false)"
+	if strings.HasPrefix(cmd.Use, "open-stream") {
+		message = "Output more information. (default false)"
+	}
+	cmd.Flags().BoolVarP(&f.IsVerbose, "verbose", "v", false, message)
 }
 
 // Validate flag values.

--- a/cmd/flag/verbose_flags.go
+++ b/cmd/flag/verbose_flags.go
@@ -15,8 +15,9 @@
 package flag
 
 import (
-	"github.com/spf13/cobra"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 type VerboseFlags struct {

--- a/cmd/groundstation/list_plans.go
+++ b/cmd/groundstation/list_plans.go
@@ -54,7 +54,7 @@ func NewListPlansCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			p := outputFormatFlags.ToPrinter()
+			p := outputFormatFlags.ToPrinter(verboseFlag.IsVerbose)
 			o := &plan.ListOptions{
 				Printer:   p,
 				ID:        args[0],

--- a/cmd/satellite/list_passes.go
+++ b/cmd/satellite/list_passes.go
@@ -52,7 +52,7 @@ func NewListAvailablePassesCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			p := outputFormatFlags.ToPrinter()
+			p := outputFormatFlags.ToPrinter(verboseFlag.IsVerbose)
 			o := &pass.ListAvailablePassesOptions{
 				Printer:      p,
 				ID:           args[0],

--- a/cmd/satellite/list_plans.go
+++ b/cmd/satellite/list_plans.go
@@ -54,7 +54,7 @@ func NewListPlansCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			p := outputFormatFlags.ToPrinter()
+			p := outputFormatFlags.ToPrinter(verboseFlag.IsVerbose)
 			o := &plan.ListOptions{
 				Printer:   p,
 				ID:        args[0],

--- a/docs/stellar_ground-station_list-plans.md
+++ b/docs/stellar_ground-station_list-plans.md
@@ -19,7 +19,7 @@ stellar ground-station list-plans [Ground Station ID] [flags]
   -d, --duration uint8      Duration of the range of plans to list (1-31), in days. Duration will be ignored when aos-before is specified. (default 31)
   -h, --help                help for list-plans
   -o, --output string       Output format. One of: csv|wide|json (default "wide")
-  -v, --verbose             Output more information. (default false)
+  -v, --verbose             Output more information in JSON format. (default false)
 ```
 
 ### SEE ALSO

--- a/docs/stellar_satellite_list-passes.md
+++ b/docs/stellar_satellite_list-passes.md
@@ -16,7 +16,7 @@ stellar satellite list-passes [Satellite ID] [flags]
   -h, --help                  help for list-passes
       --min-elevation float   The minimum elevation of passes. Passes are listed having max elevation greater than the minimum elevation. (default 10)
   -o, --output string         Output format. One of: csv|wide|json (default "wide")
-  -v, --verbose               Output more information. (default false)
+  -v, --verbose               Output more information in JSON format. (default false)
 ```
 
 ### SEE ALSO

--- a/docs/stellar_satellite_list-plans.md
+++ b/docs/stellar_satellite_list-plans.md
@@ -19,7 +19,7 @@ stellar satellite list-plans [Satellite ID] [flags]
   -d, --duration uint8      Duration of the range of plans to list (1-31), in days. Duration will be ignored when aos-before is specified. (default 31)
   -h, --help                help for list-plans
   -o, --output string       Output format. One of: csv|wide|json (default "wide")
-  -v, --verbose             Output more information. (default false)
+  -v, --verbose             Output more information in JSON format. (default false)
 ```
 
 ### SEE ALSO

--- a/pkg/satellite/plan/list_plans.go
+++ b/pkg/satellite/plan/list_plans.go
@@ -139,6 +139,16 @@ func ListPlans(o *ListOptions) {
 			uplink["bitrate"] = channelSet.Uplink.Bitrate
 		}
 
+		var telemetryMetadata []map[string]interface{}
+		if len(plan.TelemetryMetadata) > 0 {
+			for _, metadata := range plan.TelemetryMetadata {
+				data := make(map[string]interface{})
+				data["url"] = metadata.Url
+				data["dataType"] = metadata.DataType
+				telemetryMetadata = append(telemetryMetadata, data)
+			}
+		}
+
 		obj := map[string]interface{}{
 			"id":          plan.Id,
 			"satelliteId": plan.SatelliteId,
@@ -161,7 +171,7 @@ func ListPlans(o *ListOptions) {
 			"unitPrice":          plan.UnitPrice,
 			"maxElevationDegree": plan.MaxElevationDegrees,
 			"maxElevationTime":   maxElevationTime,
-			"telemetryMetadata":  plan.TelemetryMetadata,
+			"telemetryMetadata":  telemetryMetadata,
 		}
 		results = append(results, obj)
 	}

--- a/pkg/satellite/plan/list_plans.go
+++ b/pkg/satellite/plan/list_plans.go
@@ -160,6 +160,7 @@ func ListPlans(o *ListOptions) {
 			"unitPrice":          plan.UnitPrice,
 			"maxElevationDegree": plan.MaxElevationDegrees,
 			"maxElevationTime":   maxElevationTime,
+			"telemetryMetadata":  plan.TelemetryMetadata,
 		}
 		results = append(results, obj)
 	}

--- a/pkg/satellite/plan/list_plans.go
+++ b/pkg/satellite/plan/list_plans.go
@@ -44,7 +44,6 @@ var listPlansVerboseTemplate = []printer.TemplateItem{
 	{"DL_FREQ_HZ", "channelSet.downlink.frequency"},
 	{"UL_FREQ_HZ", "channelSet.uplink.frequency"},
 	{"UNIT_PRICE", "unitPrice"},
-	{"TELEMETRY_METADATA", "telemetryMetadata"},
 }
 
 var listPlansTemplate = []printer.TemplateItem{

--- a/pkg/satellite/plan/list_plans.go
+++ b/pkg/satellite/plan/list_plans.go
@@ -44,6 +44,7 @@ var listPlansVerboseTemplate = []printer.TemplateItem{
 	{"DL_FREQ_HZ", "channelSet.downlink.frequency"},
 	{"UL_FREQ_HZ", "channelSet.uplink.frequency"},
 	{"UNIT_PRICE", "unitPrice"},
+	{"TELEMETRY_METADATA", "telemetryMetadata"},
 }
 
 var listPlansTemplate = []printer.TemplateItem{

--- a/util/docs/markdown/README.md
+++ b/util/docs/markdown/README.md
@@ -1,0 +1,7 @@
+## Generate docs
+
+Run this command from stellarcli root to generate docs for all cli commands.
+
+```bash
+$ go run util/docs/markdown/gen_markdown.go
+```

--- a/util/docs/markdown/gen_markdown.go
+++ b/util/docs/markdown/gen_markdown.go
@@ -25,7 +25,7 @@ import (
 func main() {
 	stellar := cmd.NewRootCommand()
 	stellar.DisableAutoGenTag = true
-	err := doc.GenMarkdownTree(stellar, "../../../docs")
+	err := doc.GenMarkdownTree(stellar, "./docs")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/util/printer/json_printer.go
+++ b/util/printer/json_printer.go
@@ -50,6 +50,8 @@ func (p *JSONPrinter) Write(r []interface{}) {
 }
 
 // Write fields with the template.
+// Prefer use of json encode then indent over marshalIndent to prevent HTML escaping,
+// which causes invalid URLs to be printed.
 func (p *JSONPrinter) WriteWithTemplate(r []map[string]interface{}, t []TemplateItem) {
 	encBuffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(encBuffer)


### PR DESCRIPTION
If verbose is true for any command, the default output format will be `JSON`. (Note: `wide` table format will not be supported)

In the future, in order to display enum values as string names vs integers when printing in JSON format, will consider migrating to this library https://godoc.org/github.com/golang/protobuf/jsonpb.