### PR TITLE
write stats log from main event loop

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -258,6 +258,7 @@ func (ss *satelliteStream) recvLoop() {
 				log.Debug("received data: streamId: %v, planId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetry.Framing, len(payload))
 				if ss.showStats {
 					metrics.collectTelemetry(telemetry)
+					metrics.tryLogStats()
 				}
 				if ss.correctOrder {
 					go func() {
@@ -295,6 +296,9 @@ func (ss *satelliteStream) recvLoop() {
 					}
 				}
 
+			}
+			if ss.showStats {
+				metrics.tryLogStats()
 			}
 		}
 	}


### PR DESCRIPTION
@woobianca saw yo might be working on CLI logging, here's an idea to clean up the stats logging during connection errors.

- make `--stats` logging a bit cleaner for the user by logging in the main recv loop instead of in a separate thread. 
- this also suppresses stats logging during connection errors.
- the downside is, no stats will be logged if no telemetry or antenna messages are sent, so even if data transfer is stalled, `--stats` does not show the updated metrics. 