### PR TITLE
STELLAR-3555 : add flag to enable writing telemetry data to file

### DIFF
--- a/cmd/flag/write_file_flags.go
+++ b/cmd/flag/write_file_flags.go
@@ -1,0 +1,47 @@
+//
+// Copyright © 2020 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+type WriteFileFlag struct {
+	FileName      string
+	TelemetryFile *os.File
+}
+
+// Add a flag to the command.
+func (f *WriteFileFlag) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.FileName, "output-file", "o", "", "[Alpha feature] The file to to write packets to. Creates file if it does not exist; appends file if it exists. (default none)")
+}
+
+// Validate flag values.
+func (f *WriteFileFlag) Validate() error {
+	if f.FileName != "" {
+		fo, err := os.OpenFile(f.FileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		f.TelemetryFile = fo
+		return err
+	}
+	return nil
+}
+
+// Create a new WriteFileFlag with default values set.
+func NewWriteFileFlag() *WriteFileFlag {
+	return &WriteFileFlag{}
+}

--- a/cmd/flag/write_file_flags.go
+++ b/cmd/flag/write_file_flags.go
@@ -28,7 +28,7 @@ type WriteFileFlag struct {
 
 // Add a flag to the command.
 func (f *WriteFileFlag) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.FileName, "output-file", "o", "", "[Alpha feature] The file to to write packets to. Creates file if it does not exist; appends file if it exists. (default none)")
+	cmd.Flags().StringVarP(&f.FileName, "output-file", "o", "", "[Alpha feature] The file to write packets to. Creates file if it does not exist; appends file if it exists. (default none)")
 }
 
 // Validate flag values.

--- a/cmd/flag/write_file_flags.go
+++ b/cmd/flag/write_file_flags.go
@@ -28,7 +28,7 @@ type WriteFileFlag struct {
 
 // Add a flag to the command.
 func (f *WriteFileFlag) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.FileName, "output-file", "o", "", "[Alpha feature] The file to write packets to. Creates file if it does not exist; appends file if it exists. (default none)")
+	cmd.Flags().StringVarP(&f.FileName, "output-file", "", "", "[Alpha feature] The file to write packets to. Creates file if it does not exist; appends to file if it already exists. (default none)")
 }
 
 // Validate flag values.

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -46,7 +46,8 @@ func NewOpenStreamCommand() *cobra.Command {
 	proxyFlags := flag.NewProxyFlags()
 	verboseFlag := flag.NewVerboseFlags()
 	statsFlag := flag.NewStatsFlag()
-	flags := flag.NewFlagSet(correctOrderFlags, debugFlag, framingFlags, openStreamFlag, planIdFlag, proxyFlags, verboseFlag, statsFlag)
+	writeFileFlag := flag.NewWriteFileFlag()
+	flags := flag.NewFlagSet(correctOrderFlags, debugFlag, framingFlags, openStreamFlag, planIdFlag, proxyFlags, verboseFlag, statsFlag, writeFileFlag)
 
 	command := &cobra.Command{
 		Use:   openStreamUse,
@@ -75,6 +76,7 @@ func NewOpenStreamCommand() *cobra.Command {
 				IsDebug:         debugFlag.IsDebug,
 				IsVerbose:       verboseFlag.IsVerbose,
 				ShowStats:       statsFlag.ShowStats,
+				TelemetryFile:   writeFileFlag.TelemetryFile,
 
 				CorrectOrder:   correctOrderFlags.CorrectOrder,
 				DelayThreshold: correctOrderFlags.DelayThreshold,

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -23,7 +23,7 @@ stellar satellite open-stream [satellite-id] [flags]
   -h, --help                       help for open-stream
       --listen-host string         Deprecated: use udp-listen-host instead.
       --listen-port uint16         Deprecated: use udp-listen-port instead.
-  -o, --output-file string         [Alpha feature] The file to write packets to. Creates file if it does not exist; appends file if it exists. (default none)
+      --output-file string         [Alpha feature] The file to write packets to. Creates file if it does not exist; appends to file if it already exists. (default none)
       --proxy string               Proxy protocol. One of: udp|tcp (default "udp")
       --send-host string           Deprecated: use udp-send-host instead.
       --send-port uint16           Deprecated: use udp-send-port instead.

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -23,7 +23,7 @@ stellar satellite open-stream [satellite-id] [flags]
   -h, --help                       help for open-stream
       --listen-host string         Deprecated: use udp-listen-host instead.
       --listen-port uint16         Deprecated: use udp-listen-port instead.
-  -o, --output-file string         [Alpha feature] The file to to write packets to. Creates file if it does not exist; appends file if it exists. (default none)
+  -o, --output-file string         [Alpha feature] The file to write packets to. Creates file if it does not exist; appends file if it exists. (default none)
       --proxy string               Proxy protocol. One of: udp|tcp (default "udp")
       --send-host string           Deprecated: use udp-send-host instead.
       --send-port uint16           Deprecated: use udp-send-port instead.

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -23,6 +23,7 @@ stellar satellite open-stream [satellite-id] [flags]
   -h, --help                       help for open-stream
       --listen-host string         Deprecated: use udp-listen-host instead.
       --listen-port uint16         Deprecated: use udp-listen-port instead.
+  -o, --output-file string         [Alpha feature] The file to to write packets to. Creates file if it does not exist; appends file if it exists. (default none)
       --proxy string               Proxy protocol. One of: udp|tcp (default "udp")
       --send-host string           Deprecated: use udp-send-host instead.
       --send-port uint16           Deprecated: use udp-send-port instead.


### PR DESCRIPTION
- adds new flag `-o` or `--output-file` to enable file writing
- will either create or append file 
- cli will exit if create/append fails
- cli will exit on write errors
- uses buffered writer

integration test indicate output file is 0-padded at the end. i think this is an issue with upstream datasource.