### PR TITLE
Increase max grpc receive size to 9MiB.

### DIFF
--- a/pkg/apiclient/conn.go
+++ b/pkg/apiclient/conn.go
@@ -47,5 +47,7 @@ func Dial() (*grpc.ClientConn, error) {
 	return grpc.Dial(
 		apiUrl,
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-		grpc.WithPerRPCCredentials(creds))
+		grpc.WithPerRPCCredentials(creds),
+		// Set receive size to a somewhat safe 9MiB.
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(9437000)))
 }


### PR DESCRIPTION
We have a hard limit of 10MB from pubsub, but generally limit to 9MiB in our code (in the case of overhead from serialization, etc).