### PR TITLE
Always print stream ID.

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -261,7 +261,7 @@ func (ss *satelliteStream) recvLoop() {
 			continue
 		}
 		if ss.streamId != res.StreamId {
-			log.Verbose("streamId: %v\n", res.StreamId)
+			log.Println("streamId: %v\n", res.StreamId)
 		}
 		ss.streamId = res.StreamId
 		if ss.showStats {

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -261,7 +261,7 @@ func (ss *satelliteStream) recvLoop() {
 			continue
 		}
 		if ss.streamId != res.StreamId {
-			log.Println("streamId: %v\n", res.StreamId)
+			log.Printf("streamId: %v\n", res.StreamId)
 		}
 		ss.streamId = res.StreamId
 		if ss.showStats {


### PR DESCRIPTION
To address the discussion in #124, we should display the stream ID even when verbose flag is not used.