### PR TITLE
Flush file writer buffer when unable to reconnect to the API

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -252,9 +252,11 @@ func (ss *satelliteStream) recvLoop() {
 					log.Printf("%s. Automatically retrying in %v", e, duration)
 				})
 			if rcErr != nil {
+				// This explicit cleanup is not the best solution and should be moved to a global
+				// (or higher-level) cleanup function.
+				ss.CloseFileWriter()
 				// Couldn't reconnect to the server, bailout.
-				log.Printf("error connecting to API stream: %v\n", err)
-				return
+				log.Fatalf("error connecting to API stream: %v\n", err)
 			}
 			log.Println("connected to the API stream.")
 		}

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -253,7 +253,8 @@ func (ss *satelliteStream) recvLoop() {
 				})
 			if rcErr != nil {
 				// Couldn't reconnect to the server, bailout.
-				log.Fatalf("error connecting to API stream: %v\n", err)
+				log.Printf("error connecting to API stream: %v\n", err)
+				return
 			}
 			log.Println("connected to the API stream.")
 		}


### PR DESCRIPTION
`log.Fatalf()` causes the CLI to exit (`os.Exit(1)`) which skips over the cleanup function and can leave data in the file writer buffer.

Returning from the receive loop should allow the buffer to flush in all cases.

I haven't tested this yet. Maybe it's better to explicitly call `ss.CloseFileWriter()` instead? 