### PR TITLE
address duplicate acks were being sent by CLI

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -305,11 +305,10 @@ func (ss *satelliteStream) recvLoop() {
 						}
 					}
 				}
-
-				// send ack & update telemetryMessageAckId in case we need to resume from disconnects
-				telemetryMessageAckId = telResponse.MessageAckId
-				ss.ackReceivedTelemetry(telResponse.MessageAckId)
 			}
+			// send ack & update telemetryMessageAckId in case we need to resume from disconnects
+			telemetryMessageAckId = telResponse.MessageAckId
+			ss.ackReceivedTelemetry(telResponse.MessageAckId)
 		case *stellarstation.SatelliteStreamResponse_StreamEvent:
 			if res.GetStreamEvent() == nil || res.GetStreamEvent().GetPlanMonitoringEvent() == nil {
 				break


### PR DESCRIPTION
- small mistake with big consequences :P
- although ack messages are small, when resent 1000 times, it  prevented high throughput when latency is high (35 Mbps vs 350 Mbps)