### PR TITLE
STELLAR-3687 Auto close stream

### DIFF
--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -23,7 +23,7 @@ import (
 var (
 	defaultEnableAutoClose = false
 	defaultAutoCloseDelay  = 5 * time.Second
-	defaultAutoCloseTIme   = ""
+	defaultAutoCloseTIme   = "2006-01-02'T'15:04:05Z"
 )
 
 type OpenStreamFlag struct {

--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -40,7 +40,7 @@ func (f *OpenStreamFlag) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVarP(&f.AutoCloseDelay, "auto-close-delay", "", defaultAutoCloseDelay,
 		"The duration to wait before ending the stream with no more data incoming. Valid time units are \"s\", \"m\". Ex 1m30s. Range 1s to 10m")
 	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", "",
-		"The datetime (in UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05")
+		"The datetime (UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05")
 }
 
 // Validate flag values.

--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -17,15 +17,32 @@ package flag
 
 import (
 	"github.com/spf13/cobra"
+	"time"
+)
+
+var (
+	defaultEnableAutoClose = false
+	defaultAutoCloseDelay  = 5 * time.Second
+	defaultAutoCloseTIme   = ""
 )
 
 type OpenStreamFlag struct {
-	StreamId string
+	EnableAutoClose bool
+	AutoCloseDelay  time.Duration
+	AutoCloseTime   string
+	StreamId        string
 }
 
 // Add a flag to the command.
 func (f *OpenStreamFlag) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.StreamId, "stream-id", "r", "", "The StreamId to resume.")
+	cmd.Flags().BoolVarP(&f.EnableAutoClose, "enable-auto-close", "", defaultEnableAutoClose,
+		"When set to true, the stream will close after a specified auto close time.")
+	cmd.Flags().DurationVarP(&f.AutoCloseDelay, "auto-close-delay", "", defaultAutoCloseDelay,
+		"The time in seconds after which to end the stream if auto close is enabled.")
+	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", defaultAutoCloseTIme,
+		"The time after which the stream will close if no more data received plus auto close delay.")
+
 }
 
 // Validate flag values.

--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -38,7 +38,7 @@ func (f *OpenStreamFlag) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&f.EnableAutoClose, "enable-auto-close", "", defaultEnableAutoClose,
 		"When set to true, the stream will close after a specified auto close time.")
 	cmd.Flags().DurationVarP(&f.AutoCloseDelay, "auto-close-delay", "", defaultAutoCloseDelay,
-		"The duration to wait before ending the stream with no more data incoming. Valid time units are \"s\", \"m\", \"h\". Ex 1m30s")
+		"The duration to wait before ending the stream with no more data incoming. Valid time units are \"s\", \"m\". Ex 1m30s. Range 1s to 10m")
 	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", "",
 		"The datetime (UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05")
 }

--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -16,8 +16,9 @@
 package flag
 
 import (
-	"github.com/spf13/cobra"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -23,7 +23,6 @@ import (
 var (
 	defaultEnableAutoClose = false
 	defaultAutoCloseDelay  = 5 * time.Second
-	defaultAutoCloseTime   = "2006-01-02'T'15:04:05Z"
 )
 
 type OpenStreamFlag struct {
@@ -39,10 +38,9 @@ func (f *OpenStreamFlag) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&f.EnableAutoClose, "enable-auto-close", "", defaultEnableAutoClose,
 		"When set to true, the stream will close after a specified auto close time.")
 	cmd.Flags().DurationVarP(&f.AutoCloseDelay, "auto-close-delay", "", defaultAutoCloseDelay,
-		"The duration to wait before ending the stream with no more data incoming.")
-	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", defaultAutoCloseTime,
-		"The datetime after which auto-closing will be enabled.")
-
+		"The duration to wait before ending the stream with no more data incoming. Valid time units are \"s\", \"m\", \"h\". Ex 1m30s")
+	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", "",
+		"The datetime (UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05")
 }
 
 // Validate flag values.

--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -23,7 +23,7 @@ import (
 var (
 	defaultEnableAutoClose = false
 	defaultAutoCloseDelay  = 5 * time.Second
-	defaultAutoCloseTIme   = "2006-01-02'T'15:04:05Z"
+	defaultAutoCloseTime   = "2006-01-02'T'15:04:05Z"
 )
 
 type OpenStreamFlag struct {
@@ -39,9 +39,9 @@ func (f *OpenStreamFlag) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&f.EnableAutoClose, "enable-auto-close", "", defaultEnableAutoClose,
 		"When set to true, the stream will close after a specified auto close time.")
 	cmd.Flags().DurationVarP(&f.AutoCloseDelay, "auto-close-delay", "", defaultAutoCloseDelay,
-		"The time in seconds after which to end the stream if auto close is enabled.")
-	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", defaultAutoCloseTIme,
-		"The time after which the stream will close if no more data received plus auto close delay.")
+		"The duration to wait before ending the stream with no more data incoming.")
+	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", defaultAutoCloseTime,
+		"The datetime after which auto-closing will be enabled.")
 
 }
 

--- a/cmd/flag/open_stream_flags.go
+++ b/cmd/flag/open_stream_flags.go
@@ -40,7 +40,7 @@ func (f *OpenStreamFlag) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVarP(&f.AutoCloseDelay, "auto-close-delay", "", defaultAutoCloseDelay,
 		"The duration to wait before ending the stream with no more data incoming. Valid time units are \"s\", \"m\". Ex 1m30s. Range 1s to 10m")
 	cmd.Flags().StringVarP(&f.AutoCloseTime, "auto-close-time", "", "",
-		"The datetime (UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05")
+		"The datetime (in UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05")
 }
 
 // Validate flag values.

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -16,11 +16,11 @@ package satellite
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"os/signal"
-
-	"github.com/spf13/cobra"
+	"time"
 
 	"github.com/infostellarinc/stellarcli/cmd/flag"
 	"github.com/infostellarinc/stellarcli/cmd/util"
@@ -61,13 +61,17 @@ func NewOpenStreamCommand() *cobra.Command {
 			if err := flags.ValidateAll(); err != nil {
 				return err
 			}
-
+			_, err := time.Parse("20201001Z102001", openStreamFlag.AutoCloseTime)
+			if err != nil {
+				return err
+			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			proxy := proxyFlags.ToProxy()
 			defer proxy.Close()
 
+			autoCloseTime, _ := time.Parse("20201001Z102001", openStreamFlag.AutoCloseTime)
 			o := &stream.SatelliteStreamOptions{
 				SatelliteID:     args[0],
 				AcceptedFraming: framingFlags.ToProtoAcceptedFraming(),
@@ -80,6 +84,10 @@ func NewOpenStreamCommand() *cobra.Command {
 
 				CorrectOrder:   correctOrderFlags.CorrectOrder,
 				DelayThreshold: correctOrderFlags.DelayThreshold,
+
+				EnableAutoClose: openStreamFlag.EnableAutoClose,
+				AutoCloseDelay:  openStreamFlag.AutoCloseDelay,
+				AutoCloseTime:   autoCloseTime,
 			}
 
 			c := make(chan os.Signal)

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -70,11 +70,8 @@ func NewOpenStreamCommand() *cobra.Command {
 				if err != nil {
 					return errors.New("couldn't parse auto close time. Please use layout 2006-01-02 15:04:05")
 				}
-				if openStreamFlag.AutoCloseDelay < 0*time.Second {
-					return errors.New("please provide a positive auto close delay duration")
-				}
-				if openStreamFlag.AutoCloseDelay > 10*time.Minute {
-					return errors.New("please provide an auto close delay duration that is less than 10 minutes")
+				if openStreamFlag.AutoCloseDelay < 1*time.Second || openStreamFlag.AutoCloseDelay > 10*time.Minute {
+					return errors.New("please provide a duration between 1s and 10m")
 				}
 			}
 

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -70,10 +70,10 @@ func NewOpenStreamCommand() *cobra.Command {
 				if err != nil {
 					return errors.New("couldn't parse auto close time. Please use layout 2006-01-02 15:04:05")
 				}
-				if openStreamFlag.AutoCloseDelay < 0 * time.Second {
+				if openStreamFlag.AutoCloseDelay < 0*time.Second {
 					return errors.New("please provide a positive auto close delay duration")
 				}
-				if openStreamFlag.AutoCloseDelay > 10 * time.Minute {
+				if openStreamFlag.AutoCloseDelay > 10*time.Minute {
 					return errors.New("please provide an auto close delay duration that is less than 10 minutes")
 				}
 			}

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -61,7 +61,7 @@ func NewOpenStreamCommand() *cobra.Command {
 			if err := flags.ValidateAll(); err != nil {
 				return err
 			}
-			_, err := time.Parse("20201001Z102001", openStreamFlag.AutoCloseTime)
+			_, err := time.Parse("2006-01-02'T'15:04:05Z", openStreamFlag.AutoCloseTime)
 			if err != nil {
 				return err
 			}
@@ -71,7 +71,7 @@ func NewOpenStreamCommand() *cobra.Command {
 			proxy := proxyFlags.ToProxy()
 			defer proxy.Close()
 
-			autoCloseTime, _ := time.Parse("20201001Z102001", openStreamFlag.AutoCloseTime)
+			autoCloseTime, _ := time.Parse("2006-01-02'T'15:04:05Z", openStreamFlag.AutoCloseTime)
 			o := &stream.SatelliteStreamOptions{
 				SatelliteID:     args[0],
 				AcceptedFraming: framingFlags.ToProtoAcceptedFraming(),

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -17,7 +17,6 @@ package satellite
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"os/signal"
@@ -26,6 +25,7 @@ import (
 	"github.com/infostellarinc/stellarcli/cmd/flag"
 	"github.com/infostellarinc/stellarcli/cmd/util"
 	"github.com/infostellarinc/stellarcli/pkg/satellite/stream"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -15,27 +15,30 @@ stellar satellite open-stream [satellite-id] [flags]
 ### Options
 
 ```
-      --accepted-framing strings   Framing type to receive. One of: IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8|WATERFALL|BITSTREAM|AX25
-      --accepted-plan-id strings   Plan ID(s) to accept data from.
-      --correct-order              When set to true, packets will be sorted by time_first_byte_received. This feature is alpha quality.
-      --debug                      Output debug information. (default false)
-      --delay-threshold duration   The maximum amount of time that packets remain in the sorting pool. (default 500ms)
-  -h, --help                       help for open-stream
-      --listen-host string         Deprecated: use udp-listen-host instead.
-      --listen-port uint16         Deprecated: use udp-listen-port instead.
-      --output-file string         [Alpha feature] The file to write packets to. Creates file if it does not exist; appends to file if it already exists. (default none)
-      --proxy string               Proxy protocol. One of: udp|tcp (default "udp")
-      --send-host string           Deprecated: use udp-send-host instead.
-      --send-port uint16           Deprecated: use udp-send-port instead.
-      --stats                      [Alpha feature] Output telemetry stats information and generate pass summaries (default false)
-  -r, --stream-id string           The StreamId to resume.
-      --tcp-listen-host string     The host to listen for TCP connection on. (default "127.0.0.1")
-      --tcp-listen-port uint16     The port used to communicate with satellite. Clients can receive and send data through the port. (default 6001)
-      --udp-listen-host string     The host to listen for packets on. (default "127.0.0.1")
-      --udp-listen-port uint16     The port stellar listens for packets on. Packets on this port will be sent to the satellite. (default 6000)
-      --udp-send-host string       The host to send UDP packets to. (default "127.0.0.1")
-      --udp-send-port uint16       The port stellar sends UDP packets to. Packets from the satellite will be sent to this port. (default 6001)
-  -v, --verbose                    Output more information. (default false)
+      --accepted-framing strings    Framing type to receive. One of: IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8|WATERFALL|BITSTREAM|AX25
+      --accepted-plan-id strings    Plan ID(s) to accept data from.
+      --auto-close-delay duration   The duration to wait before ending the stream with no more data incoming. Valid time units are "s", "m". Ex 1m30s. Range 1s to 10m (default 5s)
+      --auto-close-time string      The datetime (in UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05
+      --correct-order               When set to true, packets will be sorted by time_first_byte_received. This feature is alpha quality.
+      --debug                       Output debug information. (default false)
+      --delay-threshold duration    The maximum amount of time that packets remain in the sorting pool. (default 500ms)
+      --enable-auto-close           When set to true, the stream will close after a specified auto close time.
+  -h, --help                        help for open-stream
+      --listen-host string          Deprecated: use udp-listen-host instead.
+      --listen-port uint16          Deprecated: use udp-listen-port instead.
+      --output-file string          [Alpha feature] The file to write packets to. Creates file if it does not exist; appends to file if it already exists. (default none)
+      --proxy string                Proxy protocol. One of: udp|tcp (default "udp")
+      --send-host string            Deprecated: use udp-send-host instead.
+      --send-port uint16            Deprecated: use udp-send-port instead.
+      --stats                       [Alpha feature] Output telemetry stats information and generate pass summaries (default false)
+  -r, --stream-id string            The StreamId to resume.
+      --tcp-listen-host string      The host to listen for TCP connection on. (default "127.0.0.1")
+      --tcp-listen-port uint16      The port used to communicate with satellite. Clients can receive and send data through the port. (default 6001)
+      --udp-listen-host string      The host to listen for packets on. (default "127.0.0.1")
+      --udp-listen-port uint16      The port stellar listens for packets on. Packets on this port will be sent to the satellite. (default 6000)
+      --udp-send-host string        The host to send UDP packets to. (default "127.0.0.1")
+      --udp-send-port uint16        The port stellar sends UDP packets to. Packets from the satellite will be sent to this port. (default 6001)
+  -v, --verbose                     Output more information. (default false)
 ```
 
 ### SEE ALSO

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -15,10 +15,10 @@ stellar satellite open-stream [satellite-id] [flags]
 ### Options
 
 ```
-      --accepted-framing strings    Framing type to receive. One of: IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8|WATERFALL|BITSTREAM|AX25
+      --accepted-framing strings    Framing type to receive. One of: AX25|IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8|WATERFALL|BITSTREAM
       --accepted-plan-id strings    Plan ID(s) to accept data from.
       --auto-close-delay duration   The duration to wait before ending the stream with no more data incoming. Valid time units are "s", "m". Ex 1m30s. Range 1s to 10m (default 5s)
-      --auto-close-time string      The datetime (in UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05
+      --auto-close-time string      The datetime (UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05
       --correct-order               When set to true, packets will be sorted by time_first_byte_received. This feature is alpha quality.
       --debug                       Output debug information. (default false)
       --delay-threshold duration    The maximum amount of time that packets remain in the sorting pool. (default 500ms)

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -356,7 +356,7 @@ func (ss *satelliteStream) recvLoop() {
 				}
 				payload := telemetry.Data
 				log.Debug("received data: streamId: %v, planId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetry.Framing, len(payload))
-				if ss.enableAutoClose && len(payload) > 0{
+				if ss.enableAutoClose && len(payload) > 0 {
 					dataStarted = true
 					receivingBytes = true
 					latestByteTime, _ := ptypes.Timestamp(telemetry.TimeLastByteReceived)

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -78,7 +78,7 @@ type satelliteStream struct {
 	recvChan           chan<- []byte
 	recvLoopClosedChan chan struct{}
 
-	latestByteTime time.Time
+	latestByteTime  time.Time
 	closeTickerChan chan struct{}
 
 	telemetryFileWriter *bufio.Writer
@@ -214,7 +214,7 @@ func (ss *satelliteStream) recvLoop() {
 		go func() {
 			for {
 				select {
-				case <- ticker.C:
+				case <-ticker.C:
 					if ss.autoCloseTime.Sub(ss.latestByteTime) < 1*time.Second {
 						if receivingBytes {
 							// Past end of auto close time, but still receiving data
@@ -233,7 +233,7 @@ func (ss *satelliteStream) recvLoop() {
 							autoCloseTimer.Reset(ss.autoCloseTime.Sub(time.Now().UTC()) + ss.autoCloseDelay)
 						}
 					}
-				case <- ss.closeTickerChan:
+				case <-ss.closeTickerChan:
 					ticker.Stop()
 					return
 				}

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -233,7 +233,7 @@ func (ss *satelliteStream) recvLoop() {
 							receivingBytes = false
 						}
 						if !dataStarted {
-							//No data yet during stream
+							// No data yet during stream
 							autoCloseTimer.Stop()
 							autoCloseTimer.Reset(ss.autoCloseTime.Sub(time.Now().UTC()) + ss.autoCloseDelay)
 						}

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -17,7 +17,6 @@ package stream
 import (
 	"bufio"
 	"context"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"io"
 	"os"
 	"sync"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/grpc"
 
 	stellarstation "github.com/infostellarinc/go-stellarstation/api/v1"

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -196,7 +196,7 @@ func (ss *satelliteStream) recvLoop() {
 	var timestampLastByteReceived *timestamp.Timestamp
 	receivingBytes := false
 	latestByteTime, _ := ptypes.Timestamp(timestampLastByteReceived)
-	d := time.Now().Add(time.Second*ss.autoCloseDelay)
+	d := time.Now().Add(time.Second * ss.autoCloseDelay)
 	ctx, cancel := context.WithDeadline(context.Background(), d)
 	defer cancel()
 
@@ -301,7 +301,7 @@ func (ss *satelliteStream) recvLoop() {
 				return
 			} else {
 				// Renew the deadline and check again after it expires
-				d := time.Now().Add(time.Second*ss.autoCloseDelay)
+				d := time.Now().Add(time.Second * ss.autoCloseDelay)
 				ctx, cancel = context.WithDeadline(context.Background(), d)
 			}
 		}

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -195,7 +195,7 @@ func (ss *satelliteStream) recvLoop() {
 	receivingBytes := false
 	var timestampLastByteReceived *timestamp.Timestamp
 	autoCloseTimer := time.AfterFunc(ss.autoCloseDelay, func() {
-		// Timer reached the end of the delay period. Closing stream and exiting stellarCLI
+		// Timer reached the end of the delay period. Closing stream and exiting
 		ss.Close()
 		panic("Stream auto-close conditions met - exiting")
 	})

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -202,6 +202,9 @@ func (ss *satelliteStream) recvLoop() {
 		autoCloseTimer := time.AfterFunc(ss.autoCloseDelay, func() {
 			// Timer reached the end of the delay period. Closing stream and exiting
 			log.Printf("Stream auto-close conditions met - exiting")
+			if ss.showStats {
+				metrics.logReport()
+			}
 			close(ss.closeTickerChan)
 			ss.Close()
 			os.Exit(0)

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -17,7 +17,6 @@ package stream
 import (
 	"bufio"
 	"context"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"io"
 	"os"
 	"sync"
@@ -193,9 +192,7 @@ func (ss *satelliteStream) recvLoop() {
 	b.MaxElapsedTime = MaxElapsedTime
 
 	// Initialize auto close
-	var timestampLastByteReceived *timestamp.Timestamp
 	receivingBytes := false
-	latestByteTime, _ := ptypes.Timestamp(timestampLastByteReceived)
 	d := time.Now().Add(time.Second * ss.autoCloseDelay)
 	ctx, cancel := context.WithDeadline(context.Background(), d)
 	defer cancel()
@@ -328,7 +325,6 @@ func (ss *satelliteStream) recvLoop() {
 				payload := telemetry.Data
 				log.Debug("received data: streamId: %v, planId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetry.Framing, len(payload))
 				if ss.enableAutoClose {
-					timestampLastByteReceived = telemetry.TimeLastByteReceived
 					receivingBytes = true
 				}
 				if ss.showStats {

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -95,7 +95,6 @@ type satelliteStream struct {
 	enableAutoClose bool
 	autoCloseDelay  time.Duration
 	autoCloseTime   time.Time
-	autoCloseTimer  *time.Timer
 }
 
 // OpenSatelliteStream opens a stream to a satellite over the StellarStation API.
@@ -439,9 +438,6 @@ func (ss *satelliteStream) start() (func(), error) {
 			metrics.logReport()
 		}
 		ss.CloseFileWriter()
-		if ss.autoCloseTimer != nil {
-			ss.autoCloseTimer.Stop()
-		}
 	}
 	return cleanup, nil
 }

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -196,8 +196,9 @@ func (ss *satelliteStream) recvLoop() {
 	var timestampLastByteReceived *timestamp.Timestamp
 	autoCloseTimer := time.AfterFunc(ss.autoCloseDelay, func() {
 		// Timer reached the end of the delay period. Closing stream and exiting
+		log.Printf("Stream auto-close conditions met - exiting")
 		ss.Close()
-		panic("Stream auto-close conditions met - exiting")
+		os.Exit(0)
 	})
 	defer autoCloseTimer.Stop()
 	autoCloseTimer.Stop()

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -295,8 +295,8 @@ func (ss *satelliteStream) recvLoop() {
 
 		select {
 		case <-ctx.Done():
-			// Close stream if auto close detects end of data
-			if ss.enableAutoClose && ss.autoCloseTime.Sub(latestByteTime) < 1*time.Second && !receivingBytes {
+			// Close stream if end of data and the current time is after auto close time
+			if ss.enableAutoClose && time.Now().UTC().After(ss.autoCloseTime) && !receivingBytes {
 				close(ss.recvLoopClosedChan)
 				return
 			} else {


### PR DESCRIPTION
There are three new flags for satellite open-stream.
--enable-auto-close           When set to true, the stream will close after a specified auto close time.
--auto-close-delay duration   The duration to wait before ending the stream with no more data incoming. (default 5s)
--auto-close-time string      The datetime after which auto-closing will be enabled. (ie "2019-12-02 15:04:05")

When enabled the stream runs normally until "auto-close-time" has passed. After this point, if no telemetry is received for "auto-close-delay" time (default 5s), then the stream will close, the file-writer is flushed (if writing to a file), and the stellarcli will close. If telemetry is received during the auto close delay period, the delay will be refreshed back to it's initial setting and will countdown to exiting again.