### PR TITLE
Disable proxy by default, remove deprecated host and port flags

### DIFF
--- a/cmd/flag/proxy_flags.go
+++ b/cmd/flag/proxy_flags.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// Default proxy protocol.
-	defaultProxyProtocol = "udp"
+	defaultProxyProtocol = "disabled"
 
 	// Supported proxy.
 	availableProxy = []string{"udp", "tcp", "disabled"}
@@ -63,11 +63,6 @@ func (f *ProxyFlags) AddFlags(cmd *cobra.Command) {
 	// Currently defaults to UDP.
 	cmd.Flags().StringVarP(&f.ProxyProtocol, "proxy", "", defaultProxyProtocol,
 		"Proxy protocol. One of: "+strings.Join(availableProxy, "|"))
-
-	cmd.Flags().StringVar(&f.UDPListenHost, "listen-host", "", "Deprecated: use udp-listen-host instead.")
-	cmd.Flags().Uint16Var(&f.UDPListenPort, "listen-port", 0, "Deprecated: use udp-listen-port instead.")
-	cmd.Flags().StringVar(&f.UDPSendHost, "send-host", "", "Deprecated: use udp-send-host instead.")
-	cmd.Flags().Uint16Var(&f.UDPSendPort, "send-port", 0, "Deprecated: use udp-send-port instead.")
 
 	cmd.Flags().StringVar(&f.UDPListenHost, "udp-listen-host", defaultUDPListenHost,
 		"The host to listen for packets on.")

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -15,7 +15,7 @@ stellar satellite open-stream [satellite-id] [flags]
 ### Options
 
 ```
-      --accepted-framing strings    Framing type to receive. One of: WATERFALL|BITSTREAM|AX25|IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8
+      --accepted-framing strings    Framing type to receive. One of: IMAGE_JPEG|FREE_TEXT_UTF8|WATERFALL|BITSTREAM|AX25|IQ|IMAGE_PNG
       --accepted-plan-id strings    Plan ID(s) to accept data from.
       --auto-close-delay duration   The duration to wait before ending the stream with no more data incoming. Valid time units are "s", "m". Ex 1m30s. Range 1s to 10m (default 5s)
       --auto-close-time string      The datetime (UTC) after which auto-closing will be enabled. Format 2006-01-02 15:04:05
@@ -24,12 +24,8 @@ stellar satellite open-stream [satellite-id] [flags]
       --delay-threshold duration    The maximum amount of time that packets remain in the sorting pool. (default 500ms)
       --enable-auto-close           When set to true, the stream will close after a specified auto close time.
   -h, --help                        help for open-stream
-      --listen-host string          Deprecated: use udp-listen-host instead.
-      --listen-port uint16          Deprecated: use udp-listen-port instead.
       --output-file string          [Alpha feature] The file to write packets to. Creates file if it does not exist; appends to file if it already exists. (default none)
-      --proxy string                Proxy protocol. One of: udp|tcp|disabled (default "udp")
-      --send-host string            Deprecated: use udp-send-host instead.
-      --send-port uint16            Deprecated: use udp-send-port instead.
+      --proxy string                Proxy protocol. One of: udp|tcp|disabled (default "disabled")
       --stats                       [Alpha feature] Output telemetry stats information and generate pass summaries (default false)
   -r, --stream-id string            The StreamId to resume.
       --tcp-listen-host string      The host to listen for TCP connection on. (default "127.0.0.1")


### PR DESCRIPTION
As mentioned in the [release notes for 0.8.0](https://github.com/infostellarinc/stellarcli/releases/tag/v0.8.0), the proxy will now default to `disabled`.

We also had a number of deprecated host and port flags from before we had TCP functionality-- these have all been superseded by the `udp-` prefixed host and port flags.