### PR TITLE
Auto close stream based on END message

### DIFF
--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -76,7 +76,7 @@ type satelliteStream struct {
 	recvChan           chan<- []byte
 	recvLoopClosedChan chan struct{}
 
-	latestByteTime  time.Time
+	latestByteTime time.Time
 
 	telemetryFileWriter *bufio.Writer
 

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -77,7 +77,6 @@ type satelliteStream struct {
 	recvLoopClosedChan chan struct{}
 
 	latestByteTime  time.Time
-	closeTickerChan chan struct{}
 
 	telemetryFileWriter *bufio.Writer
 
@@ -114,7 +113,6 @@ func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan<- []byte) (Sat
 		delayThreshold: o.DelayThreshold,
 
 		enableAutoClose: o.EnableAutoClose,
-		closeTickerChan: make(chan struct{}),
 	}
 
 	cleanup, err := s.start()
@@ -187,7 +185,6 @@ func (ss *satelliteStream) performAutoClose() {
 	if ss.showStats {
 		metrics.logReport()
 	}
-	close(ss.closeTickerChan)
 	ss.Close()
 	os.Exit(0)
 }
@@ -204,9 +201,6 @@ func (ss *satelliteStream) recvLoop() {
 					if streamEndDetected {
 						ss.performAutoClose()
 					}
-				case <-ss.closeTickerChan:
-					ticker.Stop()
-					return
 				}
 			}
 		}()

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -73,10 +73,8 @@ type satelliteStream struct {
 	streamId    string
 	planId      string
 
-	recvChan           chan<- []byte
-	recvLoopClosedChan chan struct{}
-
-	latestByteTime time.Time
+	receiveChan           chan<- []byte
+	receiveLoopClosedChan chan struct{}
 
 	telemetryFileWriter *bufio.Writer
 
@@ -95,19 +93,19 @@ type satelliteStream struct {
 }
 
 // OpenSatelliteStream opens a stream to a satellite over the StellarStation API.
-func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan<- []byte) (SatelliteStream, func(), error) {
-	s := &satelliteStream{
-		acceptedFraming:    o.AcceptedFraming,
-		satelliteId:        o.SatelliteID,
-		streamId:           o.StreamId,
-		planId:             o.PlanId,
-		recvChan:           recvChan,
-		state:              OPEN,
-		recvLoopClosedChan: make(chan struct{}),
-		isDebug:            o.IsDebug,
-		isVerbose:          o.IsVerbose,
-		showStats:          o.ShowStats,
-		telemetryFile:      o.TelemetryFile,
+func OpenSatelliteStream(o *SatelliteStreamOptions, receiveChan chan<- []byte) (SatelliteStream, func(), error) {
+	satelliteStream := &satelliteStream{
+		acceptedFraming:       o.AcceptedFraming,
+		satelliteId:           o.SatelliteID,
+		streamId:              o.StreamId,
+		planId:                o.PlanId,
+		receiveChan:           receiveChan,
+		state:                 OPEN,
+		receiveLoopClosedChan: make(chan struct{}),
+		isDebug:               o.IsDebug,
+		isVerbose:             o.IsVerbose,
+		showStats:             o.ShowStats,
+		telemetryFile:         o.TelemetryFile,
 
 		correctOrder:   o.CorrectOrder,
 		delayThreshold: o.DelayThreshold,
@@ -115,14 +113,14 @@ func OpenSatelliteStream(o *SatelliteStreamOptions, recvChan chan<- []byte) (Sat
 		enableAutoClose: o.EnableAutoClose,
 	}
 
-	cleanup, err := s.start()
+	cleanup, err := satelliteStream.start()
 
-	return s, cleanup, err
+	return satelliteStream, cleanup, err
 }
 
 // Send sends a packet to the satellite.
 func (ss *satelliteStream) Send(payload []byte) error {
-	req := stellarstation.SatelliteStreamRequest{
+	satelliteStreamRequest := stellarstation.SatelliteStreamRequest{
 		SatelliteId: ss.satelliteId,
 		Request: &stellarstation.SatelliteStreamRequest_SendSatelliteCommandsRequest{
 			SendSatelliteCommandsRequest: &stellarstation.SendSatelliteCommandsRequest{
@@ -133,7 +131,7 @@ func (ss *satelliteStream) Send(payload []byte) error {
 
 	log.Verbose("sent data: size: %d bytes\n", len(payload))
 
-	return ss.stream.Send(&req)
+	return ss.stream.Send(&satelliteStreamRequest)
 }
 
 // Close closes the stream.
@@ -143,7 +141,7 @@ func (ss *satelliteStream) Close() error {
 	ss.stream.CloseSend()
 	ss.conn.Close()
 
-	<-ss.recvLoopClosedChan
+	<-ss.receiveLoopClosedChan
 
 	ss.CloseFileWriter()
 
@@ -166,7 +164,7 @@ func (ss *satelliteStream) CloseFileWriter() error {
 // send telemetryMessageAckId to support enableFlowControl feature
 func (ss *satelliteStream) ackReceivedTelemetry(telemetryMessageAckId string) {
 	if telemetryMessageAckId != "" {
-		req := stellarstation.SatelliteStreamRequest{
+		satelliteStreamRequest := stellarstation.SatelliteStreamRequest{
 			SatelliteId: ss.satelliteId,
 			Request: &stellarstation.SatelliteStreamRequest_TelemetryReceivedAck{
 				TelemetryReceivedAck: &stellarstation.ReceiveTelemetryAck{
@@ -176,7 +174,7 @@ func (ss *satelliteStream) ackReceivedTelemetry(telemetryMessageAckId string) {
 			},
 		}
 		log.Debug("sending ack index: %v", telemetryMessageAckId)
-		ss.stream.Send(&req)
+		ss.stream.Send(&satelliteStreamRequest)
 	}
 }
 
@@ -189,26 +187,24 @@ func (ss *satelliteStream) performAutoClose() {
 	os.Exit(0)
 }
 
-func (ss *satelliteStream) recvLoop() {
+func (ss *satelliteStream) receiveLoop() {
 	streamEndDetected := false
 
 	if ss.enableAutoClose {
 		ticker := time.NewTicker(1 * time.Second)
 		go func() {
 			for {
-				select {
-				case <-ticker.C:
-					if streamEndDetected {
-						ss.performAutoClose()
-					}
+				<-ticker.C
+				if streamEndDetected {
+					ss.performAutoClose()
 				}
 			}
 		}()
 	}
 
 	// Initialize exponential back off settings.
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = MaxElapsedTime
+	backOff := backoff.NewExponentialBackOff()
+	backOff.MaxElapsedTime = MaxElapsedTime
 
 	// file writer for telemetry data
 	if ss.telemetryFile != nil {
@@ -245,7 +241,7 @@ func (ss *satelliteStream) recvLoop() {
 		// Flush half of the data in the priority queue
 		for i := 0; i < numFlush; i++ {
 			telemetry := pq.Pop().(*stellarstation.Telemetry)
-			ss.recvChan <- telemetry.Data
+			ss.receiveChan <- telemetry.Data
 			if ss.telemetryFileWriter != nil {
 				if _, err := ss.telemetryFileWriter.Write(telemetry.Data); err != nil {
 					panic(err)
@@ -256,17 +252,17 @@ func (ss *satelliteStream) recvLoop() {
 	})
 
 	for {
-		res, err := ss.stream.Recv()
+		streamResponse, err := ss.stream.Recv()
 		if atomic.LoadUint32(&ss.state) == CLOSED {
 			// Closed, so just shutdown the loop.
-			close(ss.recvLoopClosedChan)
+			close(ss.receiveLoopClosedChan)
 			return
 		}
 		if err != nil {
 			log.Println(err)
 			log.Println("reconnecting to the API stream.")
 
-			rcErr := backoff.RetryNotify(func() error {
+			reconnectError := backoff.RetryNotify(func() error {
 				err := ss.openStream(telemetryMessageAckId)
 				if err != nil {
 					return err
@@ -276,14 +272,14 @@ func (ss *satelliteStream) recvLoop() {
 				if err != nil {
 					return err
 				}
-				res = response
+				streamResponse = response
 
 				return nil
-			}, b,
+			}, backOff,
 				func(e error, duration time.Duration) {
 					log.Printf("%s. Automatically retrying in %v", e, duration)
 				})
-			if rcErr != nil {
+			if reconnectError != nil {
 				// This explicit cleanup is not the best solution and should be moved to a global
 				// (or higher-level) cleanup function.
 				ss.CloseFileWriter()
@@ -292,37 +288,33 @@ func (ss *satelliteStream) recvLoop() {
 			}
 			log.Println("connected to the API stream.")
 		}
-		if res == nil {
+		if streamResponse == nil {
 			continue
 		}
-		if ss.streamId != res.StreamId {
-			log.Printf("streamId: %v\n", res.StreamId)
+		if ss.streamId != streamResponse.StreamId {
+			log.Printf("streamId: %v\n", streamResponse.StreamId)
 		}
-		ss.streamId = res.StreamId
+		ss.streamId = streamResponse.StreamId
 		if ss.showStats {
 			metrics.setStreamId(ss.streamId)
 		}
 
-		switch res.Response.(type) {
+		switch streamResponse.Response.(type) {
 		case *stellarstation.SatelliteStreamResponse_ReceiveTelemetryResponse:
-			telResponse := res.GetReceiveTelemetryResponse()
-			if telResponse == nil {
+			telemetryResponse := streamResponse.GetReceiveTelemetryResponse()
+			if telemetryResponse == nil {
 				break
 			}
-			planId := telResponse.PlanId
+			planId := telemetryResponse.PlanId
 			if ss.showStats {
 				metrics.setPlanId(planId)
 			}
-
-			for _, telemetry := range telResponse.Telemetry {
+			for _, telemetry := range telemetryResponse.Telemetry {
 				if telemetry == nil {
 					break
 				}
-				payload := telemetry.Data
-				log.Debug("received data: streamId: %v, planId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetry.Framing, len(payload))
-				if ss.enableAutoClose && len(payload) == 0 {
-					streamEndDetected = true
-				}
+				telemetryData := telemetry.Data
+				log.Debug("received data: streamId: %v, planId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetry.Framing, len(telemetryData))
 				if ss.showStats {
 					metrics.collectTelemetry(telemetry)
 				}
@@ -333,36 +325,40 @@ func (ss *satelliteStream) recvLoop() {
 						pq.Push(telemetry)
 					}()
 				} else {
-					ss.recvChan <- payload
+					ss.receiveChan <- telemetryData
 					if ss.telemetryFileWriter != nil {
-						if _, err := ss.telemetryFileWriter.Write(payload); err != nil {
+						if _, err := ss.telemetryFileWriter.Write(telemetryData); err != nil {
 							panic(err)
 						}
 					}
 				}
 			}
 			// Send ack & update telemetryMessageAckId in case we need to resume from disconnects
-			telemetryMessageAckId = telResponse.MessageAckId
-			ss.ackReceivedTelemetry(telResponse.MessageAckId)
+			telemetryMessageAckId = telemetryResponse.MessageAckId
+			ss.ackReceivedTelemetry(telemetryResponse.MessageAckId)
+
+			// A telemetryResponse containing one telemetry message with a size of zero indicates the stream END message.
+			if ss.enableAutoClose && len(telemetryResponse.Telemetry) == 1 && len(telemetryResponse.Telemetry[0].Data) == 0 {
+				streamEndDetected = true
+			}
 		case *stellarstation.SatelliteStreamResponse_StreamEvent:
-			if res.GetStreamEvent() == nil || res.GetStreamEvent().GetPlanMonitoringEvent() == nil {
+			if streamResponse.GetStreamEvent() == nil || streamResponse.GetStreamEvent().GetPlanMonitoringEvent() == nil {
 				break
 			}
-			streamEvent := res.GetStreamEvent()
+			streamEvent := streamResponse.GetStreamEvent()
 			monitoringEvent := streamEvent.GetPlanMonitoringEvent()
 			planId := monitoringEvent.PlanId
 
 			if ss.isVerbose {
 				if gsState := monitoringEvent.GetGroundStationState(); gsState != nil {
-					if a := gsState.Antenna; a != nil && a.Azimuth != nil && a.Elevation != nil {
-						log.Verbose("planId: %v, azimuth: %v, elevation: %v\n", planId, a.Azimuth.Measured, a.Elevation.Measured)
+					if antennaState := gsState.Antenna; antennaState != nil && antennaState.Azimuth != nil && antennaState.Elevation != nil {
+						log.Verbose("planId: %v, azimuth: %v, elevation: %v\n", planId, antennaState.Azimuth.Measured, antennaState.Elevation.Measured)
 					}
 
-					if rcv := gsState.Receiver; rcv != nil {
-						log.Verbose("central frequency (MHz): %.2f\n", float64(rcv.CenterFrequencyHz)/1e6)
+					if receiverState := gsState.Receiver; receiverState != nil {
+						log.Verbose("central frequency (MHz): %.2f\n", float64(receiverState.CenterFrequencyHz)/1e6)
 					}
 				}
-
 			}
 		}
 	}
@@ -382,7 +378,7 @@ func (ss *satelliteStream) openStream(resumeStreamMessageAckId string) error {
 		return err
 	}
 
-	req := stellarstation.SatelliteStreamRequest{
+	satelliteStreamRequest := stellarstation.SatelliteStreamRequest{
 		AcceptedFraming:          ss.acceptedFraming,
 		SatelliteId:              ss.satelliteId,
 		StreamId:                 ss.streamId,
@@ -391,10 +387,10 @@ func (ss *satelliteStream) openStream(resumeStreamMessageAckId string) error {
 	}
 
 	if ss.planId != "" {
-		req.PlanId = ss.planId
+		satelliteStreamRequest.PlanId = ss.planId
 	}
 
-	err = stream.Send(&req)
+	err = stream.Send(&satelliteStreamRequest)
 	if err != nil {
 		conn.Close()
 		return err
@@ -428,7 +424,7 @@ func (ss *satelliteStream) start() (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	go ss.recvLoop()
+	go ss.receiveLoop()
 
 	// return a cleanup function to exec on exit
 	cleanup := func() {


### PR DESCRIPTION
This replaces the previous `--enable-auto-close=true` with a new method of detecting the end of a stream. It relies on the plan's actual end time. Note that the two additional flags to be used in conjunction with the previous auto-close were removed (in a different PR [here](https://github.com/infostellarinc/stellarcli/pull/148)) `--auto-close-delay` and `--auto-close-time`, and this flag is designed to be used without those additional flags.