### PR TITLE
[STS-636] Bump API version to 0.13.0, add groundStationId flag

### DIFF
--- a/cmd/flag/ground_station_id_flags.go
+++ b/cmd/flag/ground_station_id_flags.go
@@ -1,0 +1,39 @@
+//
+// Copyright © 2022 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type GroundStationIdFlag struct {
+	GroundStationId string
+}
+
+// Add a flag to the command.
+func (f *GroundStationIdFlag) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.GroundStationId, "ground-station-id", "", "Ground station ID to stream data for.")
+}
+
+// Validate flag values.
+func (f *GroundStationIdFlag) Validate() error {
+	return nil
+}
+
+// Create a new GroundStationIdFlag with default values set.
+func NewGroundStationIdFlag() *GroundStationIdFlag {
+	return &GroundStationIdFlag{}
+}

--- a/cmd/satellite/open_stream.go
+++ b/cmd/satellite/open_stream.go
@@ -41,13 +41,14 @@ func NewOpenStreamCommand() *cobra.Command {
 	debugFlag := flag.NewDebugFlag()
 	correctOrderFlags := flag.NewCorrectOrderFlags()
 	framingFlags := flag.NewFramingFlags()
+	groundStationIdFlag := flag.NewGroundStationIdFlag()
 	openStreamFlag := flag.NewOpenStreamFlag()
 	planIdFlag := flag.NewPlanIdFlag()
 	proxyFlags := flag.NewProxyFlags()
 	verboseFlag := flag.NewVerboseFlags()
 	statsFlag := flag.NewStatsFlag()
 	writeFileFlag := flag.NewWriteFileFlag()
-	flags := flag.NewFlagSet(correctOrderFlags, debugFlag, framingFlags, openStreamFlag, planIdFlag, proxyFlags, verboseFlag, statsFlag, writeFileFlag)
+	flags := flag.NewFlagSet(correctOrderFlags, debugFlag, framingFlags, groundStationIdFlag, openStreamFlag, planIdFlag, proxyFlags, verboseFlag, statsFlag, writeFileFlag)
 
 	command := &cobra.Command{
 		Use:   openStreamUse,
@@ -73,6 +74,7 @@ func NewOpenStreamCommand() *cobra.Command {
 				AcceptedFraming: framingFlags.ToProtoAcceptedFraming(),
 				StreamId:        openStreamFlag.StreamId,
 				PlanId:          planIdFlag.PlanId,
+				GroundStationId: groundStationIdFlag.GroundStationId,
 				IsDebug:         debugFlag.IsDebug,
 				IsVerbose:       verboseFlag.IsVerbose,
 				ShowStats:       statsFlag.ShowStats,

--- a/docs/stellar_satellite_open-stream.md
+++ b/docs/stellar_satellite_open-stream.md
@@ -16,24 +16,25 @@ stellar satellite open-stream [satellite-id] [flags]
 ### Options
 
 ```
-      --accepted-framing strings   Framing type to receive. One of: IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8|WATERFALL|BITSTREAM|AX25
-      --correct-order              When set to true, packets will be sorted by time_first_byte_received. This feature is alpha quality.
-      --debug                      Output debug information. (default false)
-      --delay-threshold duration   The maximum amount of time that packets remain in the sorting pool. (default 500ms)
-      --enable-auto-close          When set to true, the stream will close after receiving the stream end message.
-  -h, --help                       help for open-stream
-      --output-file string         [Alpha feature] The file to write packets to. Creates file if it does not exist; appends to file if it already exists. (default none)
-      --plan-id string             Plan ID to stream data for.
-      --proxy string               Proxy protocol. One of: udp|tcp|disabled (default "disabled")
-      --stats                      [Alpha feature] Output telemetry stats information and generate pass summaries (default false)
-  -r, --stream-id string           The StreamId to resume.
-      --tcp-listen-host string     The host to listen for TCP connection on. (default "127.0.0.1")
-      --tcp-listen-port uint16     The port used to communicate with satellite. Clients can receive and send data through the port. (default 6001)
-      --udp-listen-host string     The host to listen for packets on. (default "127.0.0.1")
-      --udp-listen-port uint16     The port stellar listens for packets on. Packets on this port will be sent to the satellite. (default 6000)
-      --udp-send-host string       The host to send UDP packets to. (default "127.0.0.1")
-      --udp-send-port uint16       The port stellar sends UDP packets to. Packets from the satellite will be sent to this port. (default 6001)
-  -v, --verbose                    Output more information. (default false)
+      --accepted-framing strings    Framing type to receive. One of: IQ|IMAGE_PNG|IMAGE_JPEG|FREE_TEXT_UTF8|WATERFALL|BITSTREAM|AX25
+      --correct-order               When set to true, packets will be sorted by time_first_byte_received. This feature is alpha quality.
+      --debug                       Output debug information. (default false)
+      --delay-threshold duration    The maximum amount of time that packets remain in the sorting pool. (default 500ms)
+      --enable-auto-close           When set to true, the stream will close after receiving the stream end message.
+      --ground-station-id string    Ground station ID to stream data for.
+  -h, --help                        help for open-stream
+      --output-file string          [Alpha feature] The file to write packets to. Creates file if it does not exist; appends to file if it already exists. (default none)
+      --plan-id string              Plan ID to stream data for.
+      --proxy string                Proxy protocol. One of: udp|tcp|disabled (default "disabled")
+      --stats                       [Alpha feature] Output telemetry stats information and generate pass summaries (default false)
+  -r, --stream-id string            The StreamId to resume.
+      --tcp-listen-host string      The host to listen for TCP connection on. (default "127.0.0.1")
+      --tcp-listen-port uint16      The port used to communicate with satellite. Clients can receive and send data through the port. (default 6001)
+      --udp-listen-host string      The host to listen for packets on. (default "127.0.0.1")
+      --udp-listen-port uint16      The port stellar listens for packets on. Packets on this port will be sent to the satellite. (default 6000)
+      --udp-send-host string        The host to send UDP packets to. (default "127.0.0.1")
+      --udp-send-port uint16        The port stellar sends UDP packets to. Packets from the satellite will be sent to this port. (default 6001)
+  -v, --verbose                     Output more information. (default false)
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/golang/protobuf v1.4.2
-	github.com/infostellarinc/go-stellarstation v0.11.0
+	github.com/infostellarinc/go-stellarstation v0.13.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,10 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/infostellarinc/go-stellarstation v0.11.0 h1:3UyO6KfybQ7EwcCIYB1gI6nTyYnlPBG6OOB/d9wvNlQ=
 github.com/infostellarinc/go-stellarstation v0.11.0/go.mod h1:++wmnJPPi8D/sdVeqST85CVqEbIquJ1DMOQJFrTqjTI=
+github.com/infostellarinc/go-stellarstation v0.12.0 h1:RefT3ky7L8XMbfrmjpSX42hByLflph/o3kMUiIgk8KM=
+github.com/infostellarinc/go-stellarstation v0.12.0/go.mod h1:++wmnJPPi8D/sdVeqST85CVqEbIquJ1DMOQJFrTqjTI=
+github.com/infostellarinc/go-stellarstation v0.13.0 h1:gk3bx/fMf0OaS8MiS1pbCJX3/yAeFivR2gP9S5CE+P4=
+github.com/infostellarinc/go-stellarstation v0.13.0/go.mod h1:++wmnJPPi8D/sdVeqST85CVqEbIquJ1DMOQJFrTqjTI=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -317,7 +317,7 @@ func (ss *satelliteStream) receiveLoop() {
 					break
 				}
 				telemetryData := telemetry.Data
-				log.Debug("received data: streamId: %v, planId: %s, groundStationId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, ss.groundStationId, telemetry.Framing, len(telemetryData))
+				log.Debug("received data: streamId: %v, planId: %s, groundStationId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetryResponse.GroundStationId, telemetry.Framing, len(telemetryData))
 				if ss.showStats {
 					metrics.collectTelemetry(telemetry)
 				}

--- a/pkg/satellite/stream/stream.go
+++ b/pkg/satellite/stream/stream.go
@@ -47,6 +47,7 @@ type SatelliteStreamOptions struct {
 	SatelliteID     string
 	StreamId        string
 	PlanId          string
+	GroundStationId string
 	IsDebug         bool
 	IsVerbose       bool
 	ShowStats       bool
@@ -67,11 +68,12 @@ type SatelliteStream interface {
 type satelliteStream struct {
 	acceptedFraming []stellarstation.Framing
 
-	satelliteId string
-	stream      stellarstation.StellarStationService_OpenSatelliteStreamClient
-	conn        *grpc.ClientConn
-	streamId    string
-	planId      string
+	satelliteId     string
+	stream          stellarstation.StellarStationService_OpenSatelliteStreamClient
+	conn            *grpc.ClientConn
+	streamId        string
+	planId          string
+	groundStationId string
 
 	receiveChan           chan<- []byte
 	receiveLoopClosedChan chan struct{}
@@ -99,6 +101,7 @@ func OpenSatelliteStream(o *SatelliteStreamOptions, receiveChan chan<- []byte) (
 		satelliteId:           o.SatelliteID,
 		streamId:              o.StreamId,
 		planId:                o.PlanId,
+		groundStationId:       o.GroundStationId,
 		receiveChan:           receiveChan,
 		state:                 OPEN,
 		receiveLoopClosedChan: make(chan struct{}),
@@ -314,7 +317,7 @@ func (ss *satelliteStream) receiveLoop() {
 					break
 				}
 				telemetryData := telemetry.Data
-				log.Debug("received data: streamId: %v, planId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, telemetry.Framing, len(telemetryData))
+				log.Debug("received data: streamId: %v, planId: %s, groundStationId: %s, framing type: %s, size: %d bytes\n", ss.streamId, planId, ss.groundStationId, telemetry.Framing, len(telemetryData))
 				if ss.showStats {
 					metrics.collectTelemetry(telemetry)
 				}
@@ -388,6 +391,10 @@ func (ss *satelliteStream) openStream(resumeStreamMessageAckId string) error {
 
 	if ss.planId != "" {
 		satelliteStreamRequest.PlanId = ss.planId
+	}
+
+	if ss.groundStationId != "" {
+		satelliteStreamRequest.GroundStationId = ss.groundStationId
 	}
 
 	err = stream.Send(&satelliteStreamRequest)


### PR DESCRIPTION
[STS-636](https://infostellar.atlassian.net/browse/STS-636)

PR 3 of 3:
1. API changes: https://github.com/infostellarinc/stellarstation-api/pull/304
2. stellarstation changes: https://github.com/infostellarinc/stellarstation/pull/6754
3. This PR